### PR TITLE
Add `NodeMetadataPayload::derive_worker_address()`

### DIFF
--- a/nucypher-core-python/src/lib.rs
+++ b/nucypher-core-python/src/lib.rs
@@ -26,13 +26,13 @@ trait FromBackend<T> {
     fn from_backend(backend: T) -> Self;
 }
 
-fn to_bytes<'a, T, U>(obj: &T) -> PyResult<PyObject>
+fn to_bytes<'a, T, U>(obj: &T) -> PyObject
 where
     T: AsBackend<U>,
     U: ProtocolObject<'a>,
 {
     let serialized = obj.as_backend().to_bytes();
-    Python::with_gil(|py| -> PyResult<PyObject> { Ok(PyBytes::new(py, &serialized).into()) })
+    Python::with_gil(|py| -> PyObject { PyBytes::new(py, &serialized).into() })
 }
 
 fn from_bytes<'a, T, U>(data: &'a [u8]) -> PyResult<T>
@@ -100,7 +100,7 @@ impl MessageKit {
         from_bytes(data)
     }
 
-    fn __bytes__(&self) -> PyResult<PyObject> {
+    fn __bytes__(&self) -> PyObject {
         to_bytes(self)
     }
 
@@ -250,7 +250,7 @@ impl EncryptedKeyFrag {
         from_bytes(data)
     }
 
-    fn __bytes__(&self) -> PyResult<PyObject> {
+    fn __bytes__(&self) -> PyObject {
         to_bytes(self)
     }
 }
@@ -360,7 +360,7 @@ impl TreasureMap {
         from_bytes(data)
     }
 
-    fn __bytes__(&self) -> PyResult<PyObject> {
+    fn __bytes__(&self) -> PyObject {
         to_bytes(self)
     }
 }
@@ -404,7 +404,7 @@ impl EncryptedTreasureMap {
         from_bytes(data)
     }
 
-    fn __bytes__(&self) -> PyResult<PyObject> {
+    fn __bytes__(&self) -> PyObject {
         to_bytes(self)
     }
 }
@@ -497,7 +497,7 @@ impl ReencryptionRequest {
         from_bytes(data)
     }
 
-    fn __bytes__(&self) -> PyResult<PyObject> {
+    fn __bytes__(&self) -> PyObject {
         to_bytes(self)
     }
 }
@@ -579,7 +579,7 @@ impl ReencryptionResponse {
         from_bytes(data)
     }
 
-    fn __bytes__(&self) -> PyResult<PyObject> {
+    fn __bytes__(&self) -> PyObject {
         to_bytes(self)
     }
 }
@@ -649,7 +649,7 @@ impl RetrievalKit {
         from_bytes(data)
     }
 
-    fn __bytes__(&self) -> PyResult<PyObject> {
+    fn __bytes__(&self) -> PyObject {
         to_bytes(self)
     }
 }
@@ -702,7 +702,7 @@ impl RevocationOrder {
         from_bytes(data)
     }
 
-    fn __bytes__(&self) -> PyResult<PyObject> {
+    fn __bytes__(&self) -> PyObject {
         to_bytes(self)
     }
 }
@@ -856,7 +856,7 @@ impl NodeMetadata {
         from_bytes(data)
     }
 
-    fn __bytes__(&self) -> PyResult<PyObject> {
+    fn __bytes__(&self) -> PyObject {
         to_bytes(self)
     }
 }
@@ -972,7 +972,7 @@ impl MetadataRequest {
         from_bytes(data)
     }
 
-    fn __bytes__(&self) -> PyResult<PyObject> {
+    fn __bytes__(&self) -> PyObject {
         to_bytes(self)
     }
 }
@@ -1060,7 +1060,7 @@ impl MetadataResponse {
         from_bytes(data)
     }
 
-    fn __bytes__(&self) -> PyResult<PyObject> {
+    fn __bytes__(&self) -> PyObject {
         to_bytes(self)
     }
 }

--- a/nucypher-core-python/src/lib.rs
+++ b/nucypher-core-python/src/lib.rs
@@ -9,7 +9,7 @@ use pyo3::pyclass::PyClass;
 use pyo3::types::{PyBytes, PyUnicode};
 use pyo3::PyObjectProtocol;
 
-use nucypher_core::ProtocolObject;
+use nucypher_core::{RECOVERABLE_SIGNATURE_SIZE, ProtocolObject};
 use umbral_pre::bindings_python::{
     Capsule, PublicKey, SecretKey, Signer, VerificationError, VerifiedCapsuleFrag, VerifiedKeyFrag,
 };
@@ -733,7 +733,7 @@ impl NodeMetadataPayload {
         certificate_bytes: &[u8],
         host: &str,
         port: u16,
-        decentralized_identity_evidence: Option<Vec<u8>>,
+        decentralized_identity_evidence: Option<[u8; RECOVERABLE_SIGNATURE_SIZE]>,
     ) -> PyResult<Self> {
         let address = try_make_address(canonical_address)?;
         Ok(Self {
@@ -746,8 +746,7 @@ impl NodeMetadataPayload {
                 certificate_bytes: certificate_bytes.into(),
                 host: host.to_string(),
                 port,
-                decentralized_identity_evidence: decentralized_identity_evidence
-                    .map(|v| v.into_boxed_slice()),
+                decentralized_identity_evidence,
             },
         })
     }

--- a/nucypher-core-python/src/lib.rs
+++ b/nucypher-core-python/src/lib.rs
@@ -680,10 +680,10 @@ impl RevocationOrder {
     #[new]
     pub fn new(
         signer: &Signer,
-        address_bytes: [u8; nucypher_core::ADDRESS_SIZE],
+        staker_address: [u8; nucypher_core::ADDRESS_SIZE],
         encrypted_kfrag: &EncryptedKeyFrag,
     ) -> Self {
-        let address = nucypher_core::Address::new(&address_bytes);
+        let address = nucypher_core::Address::new(&staker_address);
         Self {
             backend: nucypher_core::RevocationOrder::new(
                 &signer.backend,
@@ -721,7 +721,7 @@ impl NodeMetadataPayload {
     #[allow(clippy::too_many_arguments)]
     #[new]
     pub fn new(
-        canonical_address: [u8; nucypher_core::ADDRESS_SIZE],
+        staker_address: [u8; nucypher_core::ADDRESS_SIZE],
         domain: &str,
         timestamp_epoch: u32,
         verifying_key: &PublicKey,
@@ -733,7 +733,7 @@ impl NodeMetadataPayload {
     ) -> Self {
         Self {
             backend: nucypher_core::NodeMetadataPayload {
-                canonical_address: nucypher_core::Address::new(&canonical_address),
+                staker_address: nucypher_core::Address::new(&staker_address),
                 domain: domain.to_string(),
                 timestamp_epoch,
                 verifying_key: verifying_key.backend,
@@ -747,8 +747,8 @@ impl NodeMetadataPayload {
     }
 
     #[getter]
-    fn canonical_address(&self) -> &[u8] {
-        self.backend.canonical_address.as_ref()
+    fn staker_address(&self) -> &[u8] {
+        self.backend.staker_address.as_ref()
     }
 
     #[getter]

--- a/nucypher-core-python/src/lib.rs
+++ b/nucypher-core-python/src/lib.rs
@@ -835,8 +835,9 @@ impl NodeMetadata {
         }
     }
 
-    pub fn verify(&self) -> bool {
-        self.backend.verify()
+    pub fn verify(&self, worker_address: &[u8]) -> bool {
+        let address = try_make_address(worker_address).unwrap();
+        self.backend.verify(&address)
     }
 
     #[getter]

--- a/nucypher-core-wasm/src/lib.rs
+++ b/nucypher-core-wasm/src/lib.rs
@@ -898,6 +898,14 @@ impl NodeMetadataPayload {
     pub fn certificate_bytes(&self) -> Box<[u8]> {
         self.0.certificate_bytes.clone()
     }
+
+    #[wasm_bindgen(js_name = deriveWorkerAddress)]
+    pub fn derive_worker_address(&self) -> Result<Vec<u8>, JsValue> {
+        self.0
+            .derive_worker_address()
+            .map(|address| address.as_ref().to_vec())
+            .map_err(map_js_err)
+    }
 }
 
 //

--- a/nucypher-core-wasm/tests/wasm.rs
+++ b/nucypher-core-wasm/tests/wasm.rs
@@ -46,7 +46,7 @@ fn make_message_kit(sk: &SecretKey, plaintext: &[u8]) -> MessageKit {
 fn make_hrac() -> HRAC {
     let publisher_verifying_key = SecretKey::random().public_key();
     let bob_verifying_key = SecretKey::random().public_key();
-    let label = "Hello, world!".as_bytes();
+    let label = b"Hello, world!";
     HRAC::new(&publisher_verifying_key, &bob_verifying_key, label)
 }
 
@@ -72,18 +72,19 @@ fn make_fleet_state_checksum() -> FleetStateChecksum {
 }
 
 fn make_node_metadata() -> NodeMetadata {
-    let canonical_address = "00000000000000000001".as_bytes();
+    let staker_address = b"00000000000000000001";
     let domain = "localhost";
     let timestamp_epoch = 1546300800;
     let verifying_key = SecretKey::random().public_key();
     let encrypting_key = SecretKey::random().public_key();
-    let certificate_bytes = "certificate_bytes".as_bytes();
+    let certificate_bytes = b"certificate_bytes";
     let host = "https://localhost.com";
     let port = 443;
-    let decentralized_identity_evidence = Some(vec![1, 2, 3]);
+    let decentralized_identity_evidence =
+        Some(b"00000000000000000000000000000001000000000000000000000000000000010".to_vec());
 
     let node_metadata_payload = NodeMetadataPayload::new(
-        canonical_address,
+        staker_address,
         domain,
         timestamp_epoch,
         &verifying_key,
@@ -116,7 +117,7 @@ fn make_metadata_response_payload() -> (MetadataResponsePayload, Vec<NodeMetadat
 #[wasm_bindgen_test]
 fn message_kit_decrypts() {
     let sk = SecretKey::random();
-    let plaintext = "Hello, world!".as_bytes();
+    let plaintext = b"Hello, world!";
     let message_kit = make_message_kit(&sk, plaintext);
 
     let decrypted = message_kit.decrypt(&sk).unwrap().to_vec();
@@ -131,7 +132,7 @@ fn message_kit_decrypt_reencrypted() {
     // Create a message kit
     let delegating_sk = SecretKey::random();
     let delegating_pk = delegating_sk.public_key();
-    let plaintext = "Hello, world!".as_bytes();
+    let plaintext = b"Hello, world!";
     let message_kit = MessageKit::new(&delegating_pk, plaintext);
 
     // Create key fragments for reencryption
@@ -178,7 +179,7 @@ fn message_kit_decrypt_reencrypted() {
 fn message_kit_to_bytes_from_bytes() {
     let sk = SecretKey::random();
     let policy_encrypting_key = sk.public_key();
-    let plaintext = "Hello, world!".as_bytes();
+    let plaintext = b"Hello, world!";
 
     let message_kit = MessageKit::new(&policy_encrypting_key, plaintext);
 
@@ -266,7 +267,7 @@ fn make_treasure_map(publisher_sk: &SecretKey, receiving_sk: &SecretKey) -> Trea
     )
     .unwrap()
     .add_kfrag(
-        "00000000000000000001",
+        b"00000000000000000001",
         &SecretKey::random().public_key(),
         &vkfrags[0].clone(),
     )
@@ -275,13 +276,13 @@ fn make_treasure_map(publisher_sk: &SecretKey, receiving_sk: &SecretKey) -> Trea
     // Also try using the consuming variant of builder:
     builder
         .add_kfrag(
-            "00000000000000000002",
+            b"00000000000000000002",
             &SecretKey::random().public_key(),
             &vkfrags[1].clone(),
         )
         .unwrap()
         .add_kfrag(
-            "00000000000000000003",
+            b"00000000000000000003",
             &SecretKey::random().public_key(),
             &vkfrags[2].clone(),
         )
@@ -353,7 +354,7 @@ fn reencryption_request_from_bytes_to_bytes() {
     // Make capsules
     let publisher_sk = SecretKey::random();
     let policy_encrypting_key = publisher_sk.public_key();
-    let plaintext = "Hello, world!".as_bytes();
+    let plaintext = b"Hello, world!";
     let message_kit = MessageKit::new(&policy_encrypting_key, plaintext);
     let capsules = vec![message_kit.capsule()];
 
@@ -401,7 +402,7 @@ fn reencryption_response_verify() {
 
     // Make capsules
     let policy_encrypting_key = alice_sk.public_key();
-    let plaintext = "Hello, world!".as_bytes();
+    let plaintext = b"Hello, world!";
     let message_kit = MessageKit::new(&policy_encrypting_key, plaintext);
     let capsules: Vec<Capsule> = kfrags.iter().map(|_| message_kit.capsule()).collect();
 
@@ -466,7 +467,7 @@ fn reencryption_response_verify() {
 #[wasm_bindgen_test]
 fn retrieval_kit() {
     // Make a message kit
-    let message_kit = make_message_kit(&SecretKey::random(), "Hello, world!".as_bytes());
+    let message_kit = make_message_kit(&SecretKey::random(), b"Hello, world!");
 
     let retrieval_kit_from_mk = RetrievalKit::from_message_kit(&message_kit);
     assert_eq!(
@@ -476,12 +477,12 @@ fn retrieval_kit() {
     );
 
     let queried_addresses = [
-        "00000000000000000001".to_string(),
-        "00000000000000000002".to_string(),
-        "00000000000000000003".to_string(),
+        b"00000000000000000001",
+        b"00000000000000000002",
+        b"00000000000000000003",
     ];
     let mut builder = RetrievalKitBuilder::new(&message_kit.capsule());
-    for address in &queried_addresses {
+    for address in queried_addresses {
         builder.add_queried_address(address).unwrap();
     }
     let retreival_kit = builder.build();
@@ -514,7 +515,7 @@ fn revocation_order() {
     let signer = Signer::new(&delegating_sk);
     let encrypted_kfrag = EncryptedKeyFrag::new(&signer, &receiving_pk, &hrac, &verified_kfrags[0]);
 
-    let ursula_address = "00000000000000000001".as_bytes();
+    let ursula_address = b"00000000000000000001";
     let revocation_order = RevocationOrder::new(&signer, ursula_address, &encrypted_kfrag).unwrap();
 
     assert!(revocation_order.verify_signature(&delegating_sk.public_key()));

--- a/nucypher-core/Cargo.toml
+++ b/nucypher-core/Cargo.toml
@@ -18,3 +18,4 @@ typenum = "1.14"
 sha3 = "0.9"
 rmp-serde = "0.15"
 k256 = { version = "0.10", default-features = false, features = ["ecdsa"]}
+signature = "1.4"

--- a/nucypher-core/Cargo.toml
+++ b/nucypher-core/Cargo.toml
@@ -17,4 +17,4 @@ generic-array = "0.14"
 typenum = "1.14"
 sha3 = "0.9"
 rmp-serde = "0.15"
-k256 = { version = "0.9", default-features = false, features = ["ecdsa"]}
+k256 = { version = "0.10", default-features = false, features = ["ecdsa"]}

--- a/nucypher-core/Cargo.toml
+++ b/nucypher-core/Cargo.toml
@@ -17,3 +17,4 @@ generic-array = "0.14"
 typenum = "1.14"
 sha3 = "0.9"
 rmp-serde = "0.15"
+k256 = { version = "0.9", default-features = false, features = ["ecdsa"]}

--- a/nucypher-core/src/address.rs
+++ b/nucypher-core/src/address.rs
@@ -1,6 +1,12 @@
 use core::convert::TryInto;
 
+use generic_array::sequence::Split;
+use generic_array::GenericArray;
+use k256::elliptic_curve::sec1::ToEncodedPoint;
+use k256::Secp256k1;
 use serde::{Deserialize, Serialize};
+use sha3::{Digest, Keccak256};
+use typenum::{U12, U20};
 
 use crate::arrays_as_bytes;
 
@@ -18,6 +24,18 @@ impl Address {
     /// Fails if the size of the slice is incorrect.
     pub fn from_slice(bytes: &[u8]) -> Option<Self> {
         bytes.try_into().ok().map(Address)
+    }
+
+    pub(crate) fn from_k256_public_key(pk: &impl ToEncodedPoint<Secp256k1>) -> Self {
+        // Canonical address is the last 20 bytes of keccak256 hash
+        // of the uncompressed public key (without the header, so 64 bytes in total).
+        let ep = pk.to_encoded_point(false);
+        let pk_bytes = ep.as_bytes();
+        let digest = Keccak256::new().chain(&pk_bytes[1..]).finalize();
+
+        let (_prefix, address): (GenericArray<u8, U12>, GenericArray<u8, U20>) = digest.split();
+
+        Self(address.into())
     }
 }
 

--- a/nucypher-core/src/address.rs
+++ b/nucypher-core/src/address.rs
@@ -1,5 +1,3 @@
-use core::convert::TryInto;
-
 use generic_array::sequence::Split;
 use generic_array::GenericArray;
 use k256::elliptic_curve::sec1::ToEncodedPoint;
@@ -15,15 +13,17 @@ use crate::arrays_as_bytes;
 // So for simplicity we just use our own type since we only need the size check.
 // Later a conversion method can be easily defined to/from `ethereum_types::Address`.
 
+/// Size of canonical Ethereum address, in bytes.
+pub const ADDRESS_SIZE: usize = 20;
+
 /// Represents an Ethereum address (20 bytes).
 #[derive(PartialEq, Debug, Serialize, Deserialize, Copy, Clone, PartialOrd, Eq, Ord)]
-pub struct Address(#[serde(with = "arrays_as_bytes")] [u8; 20]);
+pub struct Address(#[serde(with = "arrays_as_bytes")] [u8; ADDRESS_SIZE]);
 
 impl Address {
-    /// Attempts to create an address from a byte slice.
-    /// Fails if the size of the slice is incorrect.
-    pub fn from_slice(bytes: &[u8]) -> Option<Self> {
-        bytes.try_into().ok().map(Address)
+    /// Creates an address from a fixed-length array.
+    pub fn new(bytes: &[u8; ADDRESS_SIZE]) -> Self {
+        Self(*bytes)
     }
 
     pub(crate) fn from_k256_public_key(pk: &impl ToEncodedPoint<Secp256k1>) -> Self {

--- a/nucypher-core/src/arrays_as_bytes.rs
+++ b/nucypher-core/src/arrays_as_bytes.rs
@@ -2,39 +2,153 @@
 // By default, `serde` serializes them as lists of integers, which in case of MessagePack
 // leads to every value >127 being prepended with a `\xcc`.
 // `serde_bytes` crate could help with that, but at the moment it only works with slices.
+// TODO: can this be made simpler? That's an awful lot of boilerplate
+// just to support arrays and Option<> of them.
 
 use core::convert::TryInto;
 use core::fmt;
+use core::marker::PhantomData;
 
 use serde::{de, Deserializer, Serializer};
 
-pub(crate) fn serialize<S, const N: usize>(obj: &[u8; N], serializer: S) -> Result<S::Ok, S::Error>
+//
+// Serialization
+//
+
+/// Types that can be serialized via this module.
+pub(crate) trait SerializeAsBytes {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer;
+}
+
+impl<const N: usize> SerializeAsBytes for [u8; N] {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(self)
+    }
+}
+
+impl<T> SerializeAsBytes for Option<T>
 where
+    T: SerializeAsBytes,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        struct Wrapper<'a, T>(&'a T);
+
+        impl<'a, T> serde::Serialize for Wrapper<'a, &'a T>
+        where
+            T: SerializeAsBytes,
+        {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                self.0.serialize(serializer)
+            }
+        }
+
+        match self {
+            Some(b) => serializer.serialize_some(&Wrapper(&b)),
+            None => serializer.serialize_none(),
+        }
+    }
+}
+
+//
+// Deserialization
+//
+
+/// Types that can be deserialized via this module.
+pub(crate) trait DeserializeAsBytes<'de>: Sized {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>;
+}
+
+impl<'de, const N: usize> DeserializeAsBytes<'de> for [u8; N] {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct BytesVisitor<const N: usize>();
+
+        impl<'de, const N: usize> de::Visitor<'de> for BytesVisitor<N> {
+            type Value = [u8; N];
+
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "byte array of length {}", N)
+            }
+
+            fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                v.try_into().map_err(de::Error::custom)
+            }
+        }
+
+        deserializer.deserialize_bytes(BytesVisitor::<N>())
+    }
+}
+
+impl<'de, T> DeserializeAsBytes<'de> for Option<T>
+where
+    T: DeserializeAsBytes<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct BytesVisitor<T>(PhantomData<T>);
+
+        impl<'de, T> de::Visitor<'de> for BytesVisitor<T>
+        where
+            T: DeserializeAsBytes<'de>,
+        {
+            type Value = Option<T>;
+
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "optional byte array")
+            }
+
+            fn visit_none<E: de::Error>(self) -> Result<Self::Value, E> {
+                Ok(None)
+            }
+
+            fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                T::deserialize(deserializer).map(Some)
+            }
+        }
+
+        deserializer.deserialize_option(BytesVisitor(PhantomData))
+    }
+}
+
+//
+// Dispatcher functions
+//
+
+pub(crate) fn serialize<T, S>(obj: &T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    T: ?Sized + SerializeAsBytes,
     S: Serializer,
 {
-    serializer.serialize_bytes(obj)
+    SerializeAsBytes::serialize(obj, serializer)
 }
 
-struct BytesVisitor<const N: usize>();
-
-impl<'de, const N: usize> de::Visitor<'de> for BytesVisitor<N> {
-    type Value = [u8; N];
-
-    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Byte array of length {}", N)
-    }
-
-    fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        v.try_into().map_err(de::Error::custom)
-    }
-}
-
-pub(crate) fn deserialize<'de, D, const N: usize>(deserializer: D) -> Result<[u8; N], D::Error>
+pub(crate) fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
 where
+    T: DeserializeAsBytes<'de>,
     D: Deserializer<'de>,
 {
-    deserializer.deserialize_bytes(BytesVisitor::<N>())
+    DeserializeAsBytes::deserialize(deserializer)
 }

--- a/nucypher-core/src/fleet_state.rs
+++ b/nucypher-core/src/fleet_state.rs
@@ -24,8 +24,8 @@ impl FleetStateChecksum {
         nodes.sort_unstable_by(|node1, node2| {
             node1
                 .payload
-                .canonical_address
-                .cmp(&node2.payload.canonical_address)
+                .staker_address
+                .cmp(&node2.payload.staker_address)
         });
 
         let checksum = nodes

--- a/nucypher-core/src/lib.rs
+++ b/nucypher-core/src/lib.rs
@@ -20,7 +20,7 @@ mod revocation_order;
 mod treasure_map;
 mod versioning;
 
-pub use address::Address;
+pub use address::{Address, ADDRESS_SIZE};
 pub use fleet_state::FleetStateChecksum;
 pub use hrac::HRAC;
 pub use key_frag::EncryptedKeyFrag;

--- a/nucypher-core/src/lib.rs
+++ b/nucypher-core/src/lib.rs
@@ -27,6 +27,7 @@ pub use key_frag::EncryptedKeyFrag;
 pub use message_kit::MessageKit;
 pub use node_metadata::{
     MetadataRequest, MetadataResponse, MetadataResponsePayload, NodeMetadata, NodeMetadataPayload,
+    RECOVERABLE_SIGNATURE_SIZE,
 };
 pub use reencryption::{ReencryptionRequest, ReencryptionResponse};
 pub use retrieval_kit::RetrievalKit;

--- a/nucypher-core/src/node_metadata.rs
+++ b/nucypher-core/src/node_metadata.rs
@@ -1,14 +1,19 @@
 use alloc::boxed::Box;
 use alloc::string::String;
 
+use k256::ecdsa::recoverable;
 use serde::{Deserialize, Serialize};
 use umbral_pre::{PublicKey, Signature, Signer};
 
 use crate::address::Address;
+use crate::arrays_as_bytes;
 use crate::fleet_state::FleetStateChecksum;
 use crate::versioning::{
     messagepack_deserialize, messagepack_serialize, ProtocolObject, ProtocolObjectInner,
 };
+
+/// The size of the Ethereum signature with the recovery byte
+pub const RECOVERABLE_SIGNATURE_SIZE: usize = recoverable::SIZE;
 
 /// Node metadata.
 #[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
@@ -31,8 +36,8 @@ pub struct NodeMetadataPayload {
     /// The port of the node's REST service.
     pub port: u16,
     /// The node's verifying key signed by the private key corresponding to the worker address.
-    #[serde(with = "serde_bytes")]
-    pub decentralized_identity_evidence: Option<Box<[u8]>>, // TODO: make its own type?
+    #[serde(with = "arrays_as_bytes")]
+    pub decentralized_identity_evidence: Option<[u8; RECOVERABLE_SIGNATURE_SIZE]>,
 }
 
 impl NodeMetadataPayload {

--- a/nucypher-core/src/node_metadata.rs
+++ b/nucypher-core/src/node_metadata.rs
@@ -57,7 +57,7 @@ pub const RECOVERABLE_SIGNATURE_SIZE: usize = recoverable::SIZE;
 #[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
 pub struct NodeMetadataPayload {
     /// The staker's Ethereum address.
-    pub canonical_address: Address,
+    pub staker_address: Address,
     /// The network identifier.
     pub domain: String,
     /// The timestamp of the metadata creation.

--- a/nucypher-core/src/revocation_order.rs
+++ b/nucypher-core/src/revocation_order.rs
@@ -13,7 +13,7 @@ use crate::versioning::{
 /// Represents a string used by characters to perform a revocation on a specific Ursula.
 #[derive(PartialEq, Debug, Serialize, Deserialize)]
 pub struct RevocationOrder {
-    ursula_address: Address,
+    staker_address: Address,
     encrypted_kfrag: EncryptedKeyFrag,
     signature: Signature,
 }
@@ -22,14 +22,14 @@ impl RevocationOrder {
     /// Create and sign a new revocation order.
     pub fn new(
         signer: &Signer,
-        ursula_address: &Address,
+        staker_address: &Address,
         encrypted_kfrag: &EncryptedKeyFrag,
     ) -> Self {
         Self {
-            ursula_address: *ursula_address,
+            staker_address: *staker_address,
             encrypted_kfrag: encrypted_kfrag.clone(),
             signature: signer
-                .sign(&[ursula_address.as_ref(), &encrypted_kfrag.to_bytes()].concat()),
+                .sign(&[staker_address.as_ref(), &encrypted_kfrag.to_bytes()].concat()),
         }
     }
 
@@ -37,7 +37,7 @@ impl RevocationOrder {
     pub fn verify_signature(&self, alice_verifying_key: &PublicKey) -> bool {
         // TODO: return an Option of something instead of returning `bool`?
         let message = [
-            self.ursula_address.as_ref(),
+            self.staker_address.as_ref(),
             &self.encrypted_kfrag.to_bytes(),
         ]
         .concat();


### PR DESCRIPTION
- Makes `NodeMetadatPayload.decentralized_identity_evidence` a fixed size array (instead of a boxed slice)
- Adds a `NodeMetadataPayload::derive_worker_address()` method to derive the worker address from the evidence
- Makes all addresses passed as bytes in Python bindings fixed size arrays (so now their length will be checked by `pyo3`-generated wrapper code)
- Remove the unnecessary `PyResult` being returned from `to_bytes()` (it is infallible)
- `NodeMetadataPayload.canonical_address` and `RevocationOrder.ursula_address` were renamed to `staker_address`.

For reviewers:
- I mimicked the signed message format used in NuCypher code (`eth_account.messages.encode_defunct()`), which is marked as deprecated. Here's our chance to possibly change it to something more recent? (pinging @cygnusv)
- The Python signing code produces a signature Rust does not understand, because the recovery byte is 27/28 instead of 0/1. At which stage should we be fixing that? In NuCypher's `TransactingPower.sign_message()`?