### PR TITLE
Updates for no-clone API in umbral-pre

### DIFF
--- a/.github/workflows/nucypher-core.yml
+++ b/.github/workflows/nucypher-core.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            rust: 1.51.0 # MSRV
+            rust: 1.56.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
 

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.51.0 # MSRV
+        toolchain: 1.56.0 # MSRV
         components: clippy
         override: true
         profile: minimal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Nothing here yet.
+### Changed
 
+- `umbral-pre` dependency bumped to 0.5 (and to match it, MSRV to 1.56, and Rust edition to 2021). The API was updated accordingly (mainly due to the no-clone approach). Note that this changes the ABI as well. ([#4])
+
+
+[#4]: https://github.com/nucypher/nucypher-core/pull/4
 
 ## [0.0.1] - 2021-12-25
 
 Initial release.
 
 
-[Unreleased]: https://github.com/nucypher/rust-umbral/compare/v0.0.1...HEAD
-[0.0.1]: https://github.com/nucypher/rust-umbral/releases/tag/v0.0.1
+[Unreleased]: https://github.com/nucypher/nucypher-core/compare/v0.0.1...HEAD
+[0.0.1]: https://github.com/nucypher/nucypher-core/releases/tag/v0.0.1

--- a/nucypher-core-python/Cargo.toml
+++ b/nucypher-core-python/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3 = "0.15"
 nucypher-core = { path = "../nucypher-core" }
-umbral-pre = { version = "0.4", features = ["bindings-python", "serde-support"] }
+umbral-pre = { version = "0.5", features = ["bindings-python", "serde-support"] }
 
 [build-dependencies]
 pyo3-build-config = "*"

--- a/nucypher-core/Cargo.toml
+++ b/nucypher-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nucypher-core"
 version = "0.0.1"
 authors = ["Bogdan Opanchuk <bogdan@opanchuk.net>"]
-edition = "2018"
+edition = "2021"
 license = "GPL-3.0-only"
 description = "Nucypher network core datastructures"
 repository = "https://github.com/nucypher/nucypher-core/tree/master/nucypher-core"
@@ -10,7 +10,7 @@ readme = "README.md"
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-umbral-pre = { version = "0.4", features = ["serde-support"] }
+umbral-pre = { version = "0.5", features = ["serde-support"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_bytes = "0.11"
 generic-array = "0.14"

--- a/nucypher-core/src/key_frag.rs
+++ b/nucypher-core/src/key_frag.rs
@@ -21,12 +21,12 @@ struct AuthorizedKeyFrag {
 }
 
 impl AuthorizedKeyFrag {
-    fn new(signer: &Signer, hrac: &HRAC, verified_kfrag: &VerifiedKeyFrag) -> Self {
+    fn new(signer: &Signer, hrac: &HRAC, verified_kfrag: VerifiedKeyFrag) -> Self {
         // Alice makes plain to Ursula that, upon decrypting this message,
         // this particular KFrag is authorized for use in the policy identified by this HRAC.
 
         // TODO (rust-umbral#73): add VerifiedKeyFrag::unverify()?
-        let kfrag = verified_kfrag.to_unverified();
+        let kfrag = verified_kfrag.unverify();
 
         let signature = signer.sign(&[hrac.as_ref(), kfrag.to_array().as_ref()].concat());
 
@@ -107,7 +107,7 @@ impl EncryptedKeyFrag {
         signer: &Signer,
         recipient_key: &PublicKey,
         hrac: &HRAC,
-        verified_kfrag: &VerifiedKeyFrag,
+        verified_kfrag: VerifiedKeyFrag,
     ) -> Self {
         let auth_kfrag = AuthorizedKeyFrag::new(signer, hrac, verified_kfrag);
         // Using Umbral for asymmetric encryption here for simplicity,

--- a/nucypher-core/src/message_kit.rs
+++ b/nucypher-core/src/message_kit.rs
@@ -47,7 +47,7 @@ impl MessageKit {
         &self,
         sk: &SecretKey,
         policy_encrypting_key: &PublicKey,
-        cfrags: &[VerifiedCapsuleFrag],
+        cfrags: impl IntoIterator<Item = VerifiedCapsuleFrag>,
     ) -> Result<Box<[u8]>, ReencryptionError> {
         decrypt_reencrypted(
             sk,

--- a/nucypher-core/src/reencryption.rs
+++ b/nucypher-core/src/reencryption.rs
@@ -94,11 +94,15 @@ fn signed_message(capsules: &[Capsule], cfrags: &[CapsuleFrag]) -> Vec<u8> {
 
 impl ReencryptionResponse {
     /// Creates and signs a new reencryption response.
-    pub fn new(signer: &Signer, capsules: &[Capsule], vcfrags: &[VerifiedCapsuleFrag]) -> Self {
+    pub fn new(
+        signer: &Signer,
+        capsules: &[Capsule],
+        vcfrags: impl IntoIterator<Item = VerifiedCapsuleFrag>,
+    ) -> Self {
         // un-verify
         let cfrags: Vec<_> = vcfrags
-            .iter()
-            .map(|vcfrag| vcfrag.to_unverified())
+            .into_iter()
+            .map(|vcfrag| vcfrag.unverify())
             .collect();
 
         let signature = signer.sign(&signed_message(capsules, &cfrags));
@@ -134,6 +138,7 @@ impl ReencryptionResponse {
         let vcfrags = self
             .cfrags
             .iter()
+            .cloned()
             .zip(capsules.iter())
             .map(|(cfrag, capsule)| {
                 cfrag.verify(

--- a/nucypher-core/src/retrieval_kit.rs
+++ b/nucypher-core/src/retrieval_kit.rs
@@ -32,10 +32,7 @@ impl RetrievalKit {
     }
 
     /// Creates a new retrieval kit recording the addresses already queried for reencryption.
-    pub fn new<I>(capsule: &Capsule, queried_addresses: I) -> Self
-    where
-        I: IntoIterator<Item = Address>,
-    {
+    pub fn new(capsule: &Capsule, queried_addresses: impl IntoIterator<Item = Address>) -> Self {
         // Can store cfrags too, if we're worried about Ursulas supplying duplicate ones.
         Self {
             capsule: *capsule,

--- a/nucypher-core/src/treasure_map.rs
+++ b/nucypher-core/src/treasure_map.rs
@@ -37,16 +37,13 @@ impl TreasureMap {
     /// Panics if `threshold` is set to 0,
     /// the number of assigned keyfrags is less than `threshold`,
     /// or if the addresses in `assigned_kfrags` repeat.
-    pub fn new<'a, I>(
+    pub fn new(
         signer: &Signer,
         hrac: &HRAC,
         policy_encrypting_key: &PublicKey,
-        assigned_kfrags: I,
+        assigned_kfrags: impl IntoIterator<Item = (Address, (PublicKey, VerifiedKeyFrag))>,
         threshold: u8,
-    ) -> Self
-    where
-        I: IntoIterator<Item = (Address, (&'a PublicKey, &'a VerifiedKeyFrag))>,
-    {
+    ) -> Self {
         // Panic here since violation of theis condition indicates a bug on the caller's side.
         assert!(threshold != 0, "threshold must be non-zero");
 
@@ -55,7 +52,7 @@ impl TreasureMap {
         for (ursula_address, (ursula_encrypting_key, verified_kfrag)) in assigned_kfrags.into_iter()
         {
             let encrypted_kfrag =
-                EncryptedKeyFrag::new(signer, ursula_encrypting_key, hrac, verified_kfrag);
+                EncryptedKeyFrag::new(signer, &ursula_encrypting_key, hrac, verified_kfrag);
             if destinations
                 .insert(ursula_address, encrypted_kfrag)
                 .is_some()


### PR DESCRIPTION
- bump `umbral-pre` to 0.5, MSRV to 1.56.0 and Rust edition to 2021
- update `umbra-pre` usage (due to the changes with cloning vs passing by value)