### PR TITLE
Renames to match the new terminology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Changed
+
+- Renamed `staker_address` to `staking_provider_address` in `NodeMetadataPayload` fields and `RevocationOrder::new` parameters. ([#10])
+- Renamed `NodeMetadataPayload.decentralized_identity_evidence` to `operator_signature`. ([#10])
+
+
+[#10]: https://github.com/nucypher/nucypher-core/pull/10
+
+
 ## [0.0.4] - 2022-02-09
 
 ### Changed

--- a/nucypher-core-python/src/lib.rs
+++ b/nucypher-core-python/src/lib.rs
@@ -729,7 +729,7 @@ impl NodeMetadataPayload {
         certificate_bytes: &[u8],
         host: &str,
         port: u16,
-        decentralized_identity_evidence: Option<[u8; RECOVERABLE_SIGNATURE_SIZE]>,
+        operator_signature: Option<[u8; RECOVERABLE_SIGNATURE_SIZE]>,
     ) -> Self {
         Self {
             backend: nucypher_core::NodeMetadataPayload {
@@ -741,7 +741,7 @@ impl NodeMetadataPayload {
                 certificate_bytes: certificate_bytes.into(),
                 host: host.to_string(),
                 port,
-                decentralized_identity_evidence,
+                operator_signature,
             },
         }
     }
@@ -766,11 +766,11 @@ impl NodeMetadataPayload {
     }
 
     #[getter]
-    fn decentralized_identity_evidence(&self) -> Option<&[u8]> {
+    fn operator_signature(&self) -> Option<&[u8]> {
         self.backend
-            .decentralized_identity_evidence
+            .operator_signature
             .as_ref()
-            .map(|boxed_evidence| boxed_evidence.as_ref())
+            .map(|boxed_signature| boxed_signature.as_ref())
     }
 
     #[getter]

--- a/nucypher-core-python/src/lib.rs
+++ b/nucypher-core-python/src/lib.rs
@@ -680,10 +680,10 @@ impl RevocationOrder {
     #[new]
     pub fn new(
         signer: &Signer,
-        staker_address: [u8; nucypher_core::ADDRESS_SIZE],
+        staking_provider_address: [u8; nucypher_core::ADDRESS_SIZE],
         encrypted_kfrag: &EncryptedKeyFrag,
     ) -> Self {
-        let address = nucypher_core::Address::new(&staker_address);
+        let address = nucypher_core::Address::new(&staking_provider_address);
         Self {
             backend: nucypher_core::RevocationOrder::new(
                 &signer.backend,
@@ -721,7 +721,7 @@ impl NodeMetadataPayload {
     #[allow(clippy::too_many_arguments)]
     #[new]
     pub fn new(
-        staker_address: [u8; nucypher_core::ADDRESS_SIZE],
+        staking_provider_address: [u8; nucypher_core::ADDRESS_SIZE],
         domain: &str,
         timestamp_epoch: u32,
         verifying_key: &PublicKey,
@@ -733,7 +733,7 @@ impl NodeMetadataPayload {
     ) -> Self {
         Self {
             backend: nucypher_core::NodeMetadataPayload {
-                staker_address: nucypher_core::Address::new(&staker_address),
+                staking_provider_address: nucypher_core::Address::new(&staking_provider_address),
                 domain: domain.to_string(),
                 timestamp_epoch,
                 verifying_key: verifying_key.backend,
@@ -747,8 +747,8 @@ impl NodeMetadataPayload {
     }
 
     #[getter]
-    fn staker_address(&self) -> &[u8] {
-        self.backend.staker_address.as_ref()
+    fn staking_provider_address(&self) -> &[u8] {
+        self.backend.staking_provider_address.as_ref()
     }
 
     #[getter]

--- a/nucypher-core-wasm/src/lib.rs
+++ b/nucypher-core-wasm/src/lib.rs
@@ -779,10 +779,10 @@ impl RevocationOrder {
     #[wasm_bindgen(constructor)]
     pub fn new(
         signer: &Signer,
-        staker_address: &[u8],
+        staking_provider_address: &[u8],
         encrypted_kfrag: &EncryptedKeyFrag,
     ) -> Result<RevocationOrder, JsValue> {
-        let address = try_make_address(staker_address)?;
+        let address = try_make_address(staking_provider_address)?;
         Ok(Self(nucypher_core::RevocationOrder::new(
             signer.inner(),
             &address,
@@ -818,7 +818,7 @@ impl NodeMetadataPayload {
     #[allow(clippy::too_many_arguments)]
     #[wasm_bindgen(constructor)]
     pub fn new(
-        staker_address: &[u8],
+        staking_provider_address: &[u8],
         domain: &str,
         timestamp_epoch: u32,
         verifying_key: &PublicKey,
@@ -828,7 +828,7 @@ impl NodeMetadataPayload {
         port: u16,
         decentralized_identity_evidence: Option<Vec<u8>>,
     ) -> Result<NodeMetadataPayload, JsValue> {
-        let address = try_make_address(staker_address)?;
+        let address = try_make_address(staking_provider_address)?;
         let evidence = decentralized_identity_evidence
             .map(|evidence| evidence.try_into())
             .transpose()
@@ -840,7 +840,7 @@ impl NodeMetadataPayload {
                 )))
             })?;
         Ok(Self(nucypher_core::NodeMetadataPayload {
-            staker_address: address,
+            staking_provider_address: address,
             domain: domain.to_string(),
             timestamp_epoch,
             verifying_key: *verifying_key.inner(), // TODO: Use * instead of clone everywhere
@@ -853,8 +853,8 @@ impl NodeMetadataPayload {
     }
 
     #[wasm_bindgen(method, getter)]
-    pub fn staker_address(&self) -> Vec<u8> {
-        self.0.staker_address.as_ref().to_vec()
+    pub fn staking_provider_address(&self) -> Vec<u8> {
+        self.0.staking_provider_address.as_ref().to_vec()
     }
 
     #[wasm_bindgen(method, getter)]

--- a/nucypher-core-wasm/src/lib.rs
+++ b/nucypher-core-wasm/src/lib.rs
@@ -826,16 +826,16 @@ impl NodeMetadataPayload {
         certificate_bytes: &[u8],
         host: &str,
         port: u16,
-        decentralized_identity_evidence: Option<Vec<u8>>,
+        operator_signature: Option<Vec<u8>>,
     ) -> Result<NodeMetadataPayload, JsValue> {
         let address = try_make_address(staking_provider_address)?;
-        let evidence = decentralized_identity_evidence
-            .map(|evidence| evidence.try_into())
+        let signature = operator_signature
+            .map(|sig| sig.try_into())
             .transpose()
-            .map_err(|evidence_vec: Vec<u8>| {
+            .map_err(|sig_vec: Vec<u8>| {
                 JsValue::from(Error::new(&format!(
-                    "Incorrect decentralized identity evidence length: {}, expected {}",
-                    evidence_vec.len(),
+                    "Incorrect operator signature length: {}, expected {}",
+                    sig_vec.len(),
                     RECOVERABLE_SIGNATURE_SIZE
                 )))
             })?;
@@ -848,7 +848,7 @@ impl NodeMetadataPayload {
             certificate_bytes: certificate_bytes.into(),
             host: host.to_string(),
             port,
-            decentralized_identity_evidence: evidence,
+            operator_signature: signature,
         }))
     }
 
@@ -868,10 +868,8 @@ impl NodeMetadataPayload {
     }
 
     #[wasm_bindgen(method, getter)]
-    pub fn decentralized_identity_evidence(&self) -> Option<Box<[u8]>> {
-        self.0
-            .decentralized_identity_evidence
-            .map(|evidence| evidence.into())
+    pub fn operator_signature(&self) -> Option<Box<[u8]>> {
+        self.0.operator_signature.map(|signature| signature.into())
     }
 
     #[wasm_bindgen(method, getter)]

--- a/nucypher-core-wasm/tests/wasm.rs
+++ b/nucypher-core-wasm/tests/wasm.rs
@@ -76,7 +76,7 @@ fn make_node_metadata() -> NodeMetadata {
     // Need to fix it to check the operator address derivation.
     let signing_key = SecretKey::from_bytes(b"01234567890123456789012345678901").unwrap();
 
-    let staker_address = b"00000000000000000001";
+    let staking_provider_address = b"00000000000000000001";
     let domain = "localhost";
     let timestamp_epoch = 1546300800;
     let verifying_key = signing_key.public_key();
@@ -88,7 +88,7 @@ fn make_node_metadata() -> NodeMetadata {
         Some(b"0000000000000000000000000000000100000000000000000000000000000001\x00".to_vec());
 
     let node_metadata_payload = NodeMetadataPayload::new(
-        staker_address,
+        staking_provider_address,
         domain,
         timestamp_epoch,
         &verifying_key,

--- a/nucypher-core-wasm/tests/wasm.rs
+++ b/nucypher-core-wasm/tests/wasm.rs
@@ -84,7 +84,7 @@ fn make_node_metadata() -> NodeMetadata {
     let certificate_bytes = b"certificate_bytes";
     let host = "https://localhost.com";
     let port = 443;
-    let decentralized_identity_evidence =
+    let operator_signature =
         Some(b"0000000000000000000000000000000100000000000000000000000000000001\x00".to_vec());
 
     let node_metadata_payload = NodeMetadataPayload::new(
@@ -96,7 +96,7 @@ fn make_node_metadata() -> NodeMetadata {
         certificate_bytes,
         host,
         port,
-        decentralized_identity_evidence,
+        operator_signature,
     )
     .unwrap();
 

--- a/nucypher-core/src/fleet_state.rs
+++ b/nucypher-core/src/fleet_state.rs
@@ -24,8 +24,8 @@ impl FleetStateChecksum {
         nodes.sort_unstable_by(|node1, node2| {
             node1
                 .payload
-                .staker_address
-                .cmp(&node2.payload.staker_address)
+                .staking_provider_address
+                .cmp(&node2.payload.staking_provider_address)
         });
 
         let checksum = nodes

--- a/nucypher-core/src/node_metadata.rs
+++ b/nucypher-core/src/node_metadata.rs
@@ -56,8 +56,8 @@ pub const RECOVERABLE_SIGNATURE_SIZE: usize = recoverable::SIZE;
 /// Node metadata.
 #[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
 pub struct NodeMetadataPayload {
-    /// The staker's Ethereum address.
-    pub staker_address: Address,
+    /// The staking provider's Ethereum address.
+    pub staking_provider_address: Address,
     /// The network identifier.
     pub domain: String,
     /// The timestamp of the metadata creation.

--- a/nucypher-core/src/node_metadata.rs
+++ b/nucypher-core/src/node_metadata.rs
@@ -75,7 +75,7 @@ pub struct NodeMetadataPayload {
     pub port: u16,
     /// The node's verifying key signed by the private key corresponding to the operator address.
     #[serde(with = "arrays_as_bytes")]
-    pub decentralized_identity_evidence: Option<[u8; RECOVERABLE_SIGNATURE_SIZE]>,
+    pub operator_signature: Option<[u8; RECOVERABLE_SIGNATURE_SIZE]>,
 }
 
 impl NodeMetadataPayload {
@@ -85,12 +85,12 @@ impl NodeMetadataPayload {
     }
 
     /// Derives the address corresponding to the public key that was used
-    /// to create `decentralized_identity_evidence`.
+    /// to create `operator_signature`.
     pub fn derive_operator_address(&self) -> Result<Address, AddressDerivationError> {
-        let evidence = self
-            .decentralized_identity_evidence
+        let signature = self
+            .operator_signature
             .ok_or(AddressDerivationError::NoSignatureInPayload)?;
-        let signature = recoverable::Signature::from_bytes(&evidence)
+        let signature = recoverable::Signature::from_bytes(&signature)
             .map_err(AddressDerivationError::InvalidSignature)?;
         let message = encode_defunct(&self.verifying_key.to_array());
         let key = signature

--- a/nucypher-core/src/revocation_order.rs
+++ b/nucypher-core/src/revocation_order.rs
@@ -13,7 +13,7 @@ use crate::versioning::{
 /// Represents a string used by characters to perform a revocation on a specific Ursula.
 #[derive(PartialEq, Debug, Serialize, Deserialize)]
 pub struct RevocationOrder {
-    staker_address: Address,
+    staking_provider_address: Address,
     encrypted_kfrag: EncryptedKeyFrag,
     signature: Signature,
 }
@@ -22,14 +22,19 @@ impl RevocationOrder {
     /// Create and sign a new revocation order.
     pub fn new(
         signer: &Signer,
-        staker_address: &Address,
+        staking_provider_address: &Address,
         encrypted_kfrag: &EncryptedKeyFrag,
     ) -> Self {
         Self {
-            staker_address: *staker_address,
+            staking_provider_address: *staking_provider_address,
             encrypted_kfrag: encrypted_kfrag.clone(),
-            signature: signer
-                .sign(&[staker_address.as_ref(), &encrypted_kfrag.to_bytes()].concat()),
+            signature: signer.sign(
+                &[
+                    staking_provider_address.as_ref(),
+                    &encrypted_kfrag.to_bytes(),
+                ]
+                .concat(),
+            ),
         }
     }
 
@@ -37,7 +42,7 @@ impl RevocationOrder {
     pub fn verify_signature(&self, alice_verifying_key: &PublicKey) -> bool {
         // TODO: return an Option of something instead of returning `bool`?
         let message = [
-            self.staker_address.as_ref(),
+            self.staking_provider_address.as_ref(),
             &self.encrypted_kfrag.to_bytes(),
         ]
         .concat();


### PR DESCRIPTION
Fixes #6

- Renamed `staker_address` to `staking_provider_address`
- Renamed `decentralized_identity_evidence` to `operator_signature`