### PR TITLE
Represent NodeMetadatapayload.operator_signature as recoverable::Signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Renamed `staker_address` to `staking_provider_address` in `NodeMetadataPayload` fields and `RevocationOrder::new` parameters. ([#10])
 - Renamed `NodeMetadataPayload.decentralized_identity_evidence` to `operator_signature`. ([#10])
+- Declared `NodeMetadataPayload.operator_signature` as `recoverable::Signature` instead of just a byte array. This allows the user to detect an invalid signature on `NodeMetadata` creation. ([#11])
 
 
 [#10]: https://github.com/nucypher/nucypher-core/pull/10
+[#11]: https://github.com/nucypher/nucypher-core/pull/11
 
 
 ## [0.0.4] - 2022-02-09

--- a/nucypher-core/src/lib.rs
+++ b/nucypher-core/src/lib.rs
@@ -36,4 +36,5 @@ pub use treasure_map::{EncryptedTreasureMap, TreasureMap};
 pub use versioning::ProtocolObject;
 
 // Re-export umbral_pre so that the users don't have to version-match.
+pub use k256;
 pub use umbral_pre;


### PR DESCRIPTION
Fixes #8

This does not change the Python/JS API, or ABI, but internally in Rust `operator_signature` is now typed and checked for correctness on creation, so it is impossible to create or deserialize a `NodeMetadataPayload` with an invalid signature. Better fail early than wait until someone calls `derive_operator_address()`. 