### PR TITLE
Typed certificates in `NodeMetadataPayload`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed `staker_address` to `staking_provider_address` in `NodeMetadataPayload` fields and `RevocationOrder::new` parameters. ([#10])
 - Renamed `NodeMetadataPayload.decentralized_identity_evidence` to `operator_signature`. ([#10])
 - Declared `NodeMetadataPayload.operator_signature` as `recoverable::Signature` instead of just a byte array. This allows the user to detect an invalid signature on `NodeMetadata` creation. ([#11])
+- Declared `NodeMetadataPayload.certificate_bytes` as `X509Certificate` instead of just a byte array. Also renamed it to `certificate`. Bindings take/return bytes, and expose a byte-typed `certificate_der` field. ([#12])
 
 
 [#10]: https://github.com/nucypher/nucypher-core/pull/10
 [#11]: https://github.com/nucypher/nucypher-core/pull/11
+[#12]: https://github.com/nucypher/nucypher-core/pull/12
 
 
 ## [0.0.4] - 2022-02-09

--- a/nucypher-core/Cargo.toml
+++ b/nucypher-core/Cargo.toml
@@ -19,3 +19,4 @@ sha3 = "0.9"
 rmp-serde = "0.15"
 k256 = { version = "0.10", default-features = false, features = ["ecdsa"]}
 signature = "1.4"
+x509-certificate = "0.6"

--- a/nucypher-core/src/lib.rs
+++ b/nucypher-core/src/lib.rs
@@ -35,6 +35,7 @@ pub use revocation_order::RevocationOrder;
 pub use treasure_map::{EncryptedTreasureMap, TreasureMap};
 pub use versioning::ProtocolObject;
 
-// Re-export umbral_pre so that the users don't have to version-match.
+// Re-export crates so that the users don't have to version-match.
 pub use k256;
 pub use umbral_pre;
+pub use x509_certificate;


### PR DESCRIPTION
- renamed `NodeMetadataPayload.certificate_bytes` to `certificate` and made it a type of [`x509_certificate::certificate::X509Certificate`](https://docs.rs/x509-certificate/latest/x509_certificate/certificate/struct.X509Certificate.html).
- bindings expose it as `certificate_der`, returning a DER-encoded certificate 
- the certificate is serialized as DER bytes

DER vs PEM is ~370 vs ~570 bytes, so not a small difference.

There is one issue though. When I serialize a certificate created in Python (in `cryptograpgy`) as DER, pass it to the Rust object, and then serialize the Rust object to DER, it returns a slightly different certificate.

Example:

Python:
```
b'0\x82\x01u0\x81\xfc\xa0\x03\x02\x01\x02\x02\x14\x1c\xfd>PM\x9a_\x07AO&C\xaeW\xd4\xa1$0\x86\x0e0\n\x06\x08*\x86H\xce=\x04\x03\x040\x121\x100\x0e\x06\x03U\x04\x03\x0c\x071.2.3.40\x1e\x17\r220306002352Z\x17\r230306002352Z0\x121\x100\x0e\x06\x03U\x04\x03\x0c\x071.2.3.40v0\x10\x06\x07*\x86H\xce=\x02\x01\x06\x05+\x81\x04\x00"\x03b\x00\x04?\x1e5\x811j\x92\xfd\t\x82\x0f\xb4\xb1\xff\xfd,?\xc1%N`\x96=\rTR\x9a[X\xd1Fca\x86\xec\xdb\x1a]\x054(\x0cm\x97\xf5\xedv\x7f\xe0~@\xfe\x17m\xfd\xe4/\x0b5\xb3\xe4\xf7Q\xf0\xd1C\x9f\x07\x8c\xf2\xdb]\x88\x13P\xc2Q\xb2Ak\t\x12\'\xcb\xaf\x8aK\xfb\x00\x9a\xee\x81\xedP\x8c2\xa3\x130\x110\x0f\x06\x03U\x1d\x11\x04\x080\x06\x87\x04\x01\x02\x03\x040\n\x06\x08*\x86H\xce=\x04\x03\x04\x03h\x000e\x020Y\xb2\xa2\x10uX\x07p\xabM\xe2L\xa23\xfbM\x8d.\x16(!\xf9\xe8\x06\xf7\xd3\x9aJ*\xf5i!\xba^\xfc\x07\x122v{\xe5\xd0\xacF\xe3{\xa4\x85\x021\x00\xac\xa9\xbb^\n\x0f\x8d?\r\xa4\xa4\xacS\xee\xe4Gh\xe9\x9a|\xd1l\xf3\x1f\x07a\x9c\xc327_\xfc2O\xe5\xea\xaa\xe4,\x0cL\x02\x80\xdd\xf2;\xe1C'
```

Rust:
```
b'0\x82\x01y0\x81\xfe\xa0\x03\x02\x01\x02\x02\x14\x1c\xfd>PM\x9a_\x07AO&C\xaeW\xd4\xa1$0\x86\x0e0\x0c\x06\x08*\x86H\xce=\x04\x03\x04\x05\x000\x121\x100\x0e\x06\x03U\x04\x03\x0c\x071.2.3.40\x1e\x17\r220306002352Z\x17\r230306002352Z0\x121\x100\x0e\x06\x03U\x04\x03\x0c\x071.2.3.40v0\x10\x06\x07*\x86H\xce=\x02\x01\x06\x05+\x81\x04\x00"\x03b\x00\x04?\x1e5\x811j\x92\xfd\t\x82\x0f\xb4\xb1\xff\xfd,?\xc1%N`\x96=\rTR\x9a[X\xd1Fca\x86\xec\xdb\x1a]\x054(\x0cm\x97\xf5\xedv\x7f\xe0~@\xfe\x17m\xfd\xe4/\x0b5\xb3\xe4\xf7Q\xf0\xd1C\x9f\x07\x8c\xf2\xdb]\x88\x13P\xc2Q\xb2Ak\t\x12\'\xcb\xaf\x8aK\xfb\x00\x9a\xee\x81\xedP\x8c2\xa3\x130\x110\x0f\x06\x03U\x1d\x11\x04\x080\x06\x87\x04\x01\x02\x03\x040\x0c\x06\x08*\x86H\xce=\x04\x03\x04\x05\x00\x03h\x000e\x020Y\xb2\xa2\x10uX\x07p\xabM\xe2L\xa23\xfbM\x8d.\x16(!\xf9\xe8\x06\xf7\xd3\x9aJ*\xf5i!\xba^\xfc\x07\x122v{\xe5\xd0\xacF\xe3{\xa4\x85\x021\x00\xac\xa9\xbb^\n\x0f\x8d?\r\xa4\xa4\xacS\xee\xe4Gh\xe9\x9a|\xd1l\xf3\x1f\x07a\x9c\xc327_\xfc2O\xe5\xea\xaa\xe4,\x0cL\x02\x80\xdd\xf2;\xe1C'
```

The difference here is two occurrences of `b'\x06\x08*\x86H\xce=\x04\x03\x04'` in Python and `b'\x06\x08*\x86H\xce=\x04\x03\x04\x05\x00'` in Rust. It is kind of at the place where OID (`1.2.840.10045.4.3.4`) would be, and looks like it, but not quite. 

The Rust version can be deserialized back into Python, but the resulting certificate is not equal to the original one. `openssl x509 -inform der` does not show any differences. 
