### PR TITLE
Be more specific about what certificate format is expected in NodeMetadataPayload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed `staker_address` to `staking_provider_address` in `NodeMetadataPayload` fields and `RevocationOrder::new` parameters. ([#10])
 - Renamed `NodeMetadataPayload.decentralized_identity_evidence` to `operator_signature`. ([#10])
 - Declared `NodeMetadataPayload.operator_signature` as `recoverable::Signature` instead of just a byte array. This allows the user to detect an invalid signature on `NodeMetadata` creation. ([#11])
+- Renamed `NodeMetadataPayload.certificate_bytes` to `certificate_der` (although it is not deserialized on the Rust side, so the DER format is not strictly enforced). ([#13])
 
 
 [#10]: https://github.com/nucypher/nucypher-core/pull/10
 [#11]: https://github.com/nucypher/nucypher-core/pull/11
+[#13]: https://github.com/nucypher/nucypher-core/pull/13
 
 
 ## [0.0.4] - 2022-02-09

--- a/nucypher-core-python/src/lib.rs
+++ b/nucypher-core-python/src/lib.rs
@@ -728,7 +728,7 @@ impl NodeMetadataPayload {
         timestamp_epoch: u32,
         verifying_key: &PublicKey,
         encrypting_key: &PublicKey,
-        certificate_bytes: &[u8],
+        certificate_der: &[u8],
         host: &str,
         port: u16,
         operator_signature: Option<[u8; RECOVERABLE_SIGNATURE_SIZE]>,
@@ -747,7 +747,7 @@ impl NodeMetadataPayload {
                 timestamp_epoch,
                 verifying_key: verifying_key.backend,
                 encrypting_key: encrypting_key.backend,
-                certificate_bytes: certificate_bytes.into(),
+                certificate_der: certificate_der.into(),
                 host: host.to_string(),
                 port,
                 operator_signature: signature,
@@ -803,8 +803,8 @@ impl NodeMetadataPayload {
     }
 
     #[getter]
-    fn certificate_bytes(&self) -> &[u8] {
-        self.backend.certificate_bytes.as_ref()
+    fn certificate_der(&self) -> &[u8] {
+        self.backend.certificate_der.as_ref()
     }
 
     fn derive_operator_address(&self) -> PyResult<PyObject> {

--- a/nucypher-core-wasm/src/lib.rs
+++ b/nucypher-core-wasm/src/lib.rs
@@ -825,7 +825,7 @@ impl NodeMetadataPayload {
         timestamp_epoch: u32,
         verifying_key: &PublicKey,
         encrypting_key: &PublicKey,
-        certificate_bytes: &[u8],
+        certificate_der: &[u8],
         host: &str,
         port: u16,
         operator_signature: Option<Vec<u8>>,
@@ -849,7 +849,7 @@ impl NodeMetadataPayload {
             timestamp_epoch,
             verifying_key: *verifying_key.inner(), // TODO: Use * instead of clone everywhere
             encrypting_key: *encrypting_key.inner(),
-            certificate_bytes: certificate_bytes.into(),
+            certificate_der: certificate_der.into(),
             host: host.to_string(),
             port,
             operator_signature: signature,
@@ -899,8 +899,8 @@ impl NodeMetadataPayload {
     }
 
     #[wasm_bindgen(method, getter)]
-    pub fn certificate_bytes(&self) -> Box<[u8]> {
-        self.0.certificate_bytes.clone()
+    pub fn certificate_der(&self) -> Box<[u8]> {
+        self.0.certificate_der.clone()
     }
 
     #[wasm_bindgen(js_name = deriveOperatorAddress)]

--- a/nucypher-core-wasm/tests/wasm.rs
+++ b/nucypher-core-wasm/tests/wasm.rs
@@ -81,7 +81,7 @@ fn make_node_metadata() -> NodeMetadata {
     let timestamp_epoch = 1546300800;
     let verifying_key = signing_key.public_key();
     let encrypting_key = SecretKey::random().public_key();
-    let certificate_bytes = b"certificate_bytes";
+    let certificate_der = b"certificate_der";
     let host = "https://localhost.com";
     let port = 443;
     let operator_signature =
@@ -93,7 +93,7 @@ fn make_node_metadata() -> NodeMetadata {
         timestamp_epoch,
         &verifying_key,
         &encrypting_key,
-        certificate_bytes,
+        certificate_der,
         host,
         port,
         operator_signature,

--- a/nucypher-core/src/node_metadata.rs
+++ b/nucypher-core/src/node_metadata.rs
@@ -98,9 +98,9 @@ pub struct NodeMetadataPayload {
     pub verifying_key: PublicKey,
     /// The node's encrypting key.
     pub encrypting_key: PublicKey,
-    /// The node's SSL certificate (serialized in PEM format).
+    /// The node's SSL certificate (serialized in DER format).
     #[serde(with = "serde_bytes")]
-    pub certificate_bytes: Box<[u8]>,
+    pub certificate_der: Box<[u8]>,
     /// The hostname of the node's REST service.
     pub host: String,
     /// The port of the node's REST service.


### PR DESCRIPTION
This is a relaxed version of #12 (which will be archived). Here we only changed `NodeMetadataPayload.certificate_bytes` to `certificate_der` to provide a hint on what certificate format is expected. Since certificates are not currently used on Rust side, we can live without deserialization for a while.

See comments in #12 about the compatibility problems between Python- and Rust-created certificates. Perhaps it will be somehow fixed in the future, or we will actually need certificate objects on Rust side and will have to deal with the differences.

A compromise would be to just deserialize the certificate on the Rust side, but not expose it - it can be added later, since it won't break backward compatibility. It just feels silly to do all the deserialization work and then not use the resulting object. According to my measurements, doing that increases deserialization time from 68us to 80us - quite noticeable on a relative scale (although it still means that a 1000 nodes, a typical size of our network, are deserialized in under 0.1s, which is negligible compared on the learning loop scale).



