### PR TITLE
Api cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,16 +13,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Declared `NodeMetadataPayload.operator_signature` as `recoverable::Signature` instead of just a byte array. This allows the user to detect an invalid signature on `NodeMetadata` creation. ([#11])
 - Renamed `NodeMetadataPayload.certificate_bytes` to `certificate_der` (although it is not deserialized on the Rust side, so the DER format is not strictly enforced). ([#13])
 - Changed some method and field names in WASM bindings to conform to JS style (camel case). New names are: `TreasureMap.publisherVerifyingKey`, `TreasureMap.bobVerifyingKey`, `TreasureMap.encryptedKfrag`, `RetrievalKit.queriedAddresses`, `RevocationOrder.verifySignature`, `NodeMetadataPayload.verifyingKey`, `NodeMetadataPayload.encryptingKey`, `NodeMetadataPayload.timestampEpoch`, `MetadataRequest.announceNodes`. ([#9])
+- Moved `ADDRESS_SIZE` to `Address::SIZE`. ([#14])
+- `MetadataResponse::verify()` and `ReencryptionResponse::verify()` return a `Result` instead of `Option`. ([#14])
+- Renamed `RevocationOrder::verify_signature()` to `verify()` and made it return a `Result<(Address, EncryptedKeyFrag)>`. ([#14])
 
 
 ### Added
 
 - `TreasureMap::make_revocation_orders()` (with the corresponding methods in Python and WASM bindings). ([#9])
-- `HRAC.fromBytes()` in WASM bindings. ([#9])
+- `HRAC.fromBytes()` in WASM bindings ([#9]), and in Python bindings ([#14]).
 - `RevocationOrder.stakingProviderAddress` in WASM bindings. ([#9])
 - `MetadataResponse.verify()` in WASM bindings. ([#9])
 - `impl From<[u8; 16]>` for `HRAC`. ([#9])
-- Made `RevocationOrder.staking_provider_address` public. ([#9])
+- Made `RevocationOrder.staking_provider_address` public. ([#9]) Rolled back in ([#14]) in favor of the return value from `verify()`.
+- `HRAC::SIZE` constant ([#14])
+- `VerificationError` for use in various `verify()` methods. ([#14])
 
 
 ### Fixed
@@ -34,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#10]: https://github.com/nucypher/nucypher-core/pull/10
 [#11]: https://github.com/nucypher/nucypher-core/pull/11
 [#13]: https://github.com/nucypher/nucypher-core/pull/13
+[#14]: https://github.com/nucypher/nucypher-core/pull/14
 
 
 ## [0.0.4] - 2022-02-09

--- a/nucypher-core-python/src/lib.rs
+++ b/nucypher-core-python/src/lib.rs
@@ -1079,11 +1079,12 @@ impl MetadataResponse {
 
     pub fn verify(&self, verifying_pk: &PublicKey) -> PyResult<MetadataResponsePayload> {
         self.backend
+            .clone()
             .verify(&verifying_pk.backend)
             .map(|backend_payload| MetadataResponsePayload {
                 backend: backend_payload,
             })
-            .ok_or_else(|| VerificationError::new_err("MetadataResponse verification failed"))
+            .map_err(|_err| VerificationError::new_err("MetadataResponse verification failed"))
     }
 
     #[staticmethod]

--- a/nucypher-core-python/src/lib.rs
+++ b/nucypher-core-python/src/lib.rs
@@ -710,13 +710,15 @@ impl RevocationOrder {
         }
     }
 
-    #[getter]
-    fn staking_provider_address(&self) -> &[u8] {
-        self.backend.staking_provider_address.as_ref()
-    }
-
-    pub fn verify_signature(&self, alice_verifying_key: &PublicKey) -> bool {
-        self.backend.verify_signature(&alice_verifying_key.backend)
+    pub fn verify(
+        &self,
+        alice_verifying_key: &PublicKey,
+    ) -> PyResult<([u8; nucypher_core::Address::SIZE], EncryptedKeyFrag)> {
+        self.backend
+            .clone()
+            .verify(&alice_verifying_key.backend)
+            .map(|(address, ekfrag)| (address.into(), EncryptedKeyFrag { backend: ekfrag }))
+            .map_err(|_err| VerificationError::new_err("RevocationOrder verification failed"))
     }
 
     #[staticmethod]

--- a/nucypher-core-python/src/lib.rs
+++ b/nucypher-core-python/src/lib.rs
@@ -173,6 +173,13 @@ impl HRAC {
         }
     }
 
+    #[staticmethod]
+    pub fn from_bytes(data: [u8; nucypher_core::HRAC::SIZE]) -> Self {
+        Self {
+            backend: data.into(),
+        }
+    }
+
     fn __bytes__(&self) -> &[u8] {
         self.backend.as_ref()
     }

--- a/nucypher-core-python/src/lib.rs
+++ b/nucypher-core-python/src/lib.rs
@@ -710,6 +710,11 @@ impl RevocationOrder {
         }
     }
 
+    #[getter]
+    fn staking_provider_address(&self) -> &[u8] {
+        self.backend.staking_provider_address.as_ref()
+    }
+
     pub fn verify_signature(&self, alice_verifying_key: &PublicKey) -> bool {
         self.backend.verify_signature(&alice_verifying_key.backend)
     }

--- a/nucypher-core-python/src/lib.rs
+++ b/nucypher-core-python/src/lib.rs
@@ -293,7 +293,7 @@ impl TreasureMap {
         signer: &Signer,
         hrac: &HRAC,
         policy_encrypting_key: &PublicKey,
-        assigned_kfrags: BTreeMap<[u8; nucypher_core::ADDRESS_SIZE], (PublicKey, VerifiedKeyFrag)>,
+        assigned_kfrags: BTreeMap<[u8; nucypher_core::Address::SIZE], (PublicKey, VerifiedKeyFrag)>,
         threshold: u8,
     ) -> Self {
         let assigned_kfrags_backend = assigned_kfrags
@@ -634,7 +634,7 @@ impl RetrievalKit {
     #[new]
     pub fn new(
         capsule: &Capsule,
-        queried_addresses: BTreeSet<[u8; nucypher_core::ADDRESS_SIZE]>,
+        queried_addresses: BTreeSet<[u8; nucypher_core::Address::SIZE]>,
     ) -> Self {
         let addresses_backend = queried_addresses
             .iter()
@@ -697,7 +697,7 @@ impl RevocationOrder {
     #[new]
     pub fn new(
         signer: &Signer,
-        staking_provider_address: [u8; nucypher_core::ADDRESS_SIZE],
+        staking_provider_address: [u8; nucypher_core::Address::SIZE],
         encrypted_kfrag: &EncryptedKeyFrag,
     ) -> Self {
         let address = nucypher_core::Address::new(&staking_provider_address);
@@ -738,7 +738,7 @@ impl NodeMetadataPayload {
     #[allow(clippy::too_many_arguments)]
     #[new]
     pub fn new(
-        staking_provider_address: [u8; nucypher_core::ADDRESS_SIZE],
+        staking_provider_address: [u8; nucypher_core::Address::SIZE],
         domain: &str,
         timestamp_epoch: u32,
         verifying_key: &PublicKey,

--- a/nucypher-core-python/src/lib.rs
+++ b/nucypher-core-python/src/lib.rs
@@ -582,7 +582,7 @@ impl ReencryptionResponse {
                 &policy_encrypting_key.backend,
                 &bob_encrypting_key.backend,
             )
-            .ok_or_else(|| PyValueError::new_err("ReencryptionResponse verification failed"))?;
+            .map_err(|_err| PyValueError::new_err("ReencryptionResponse verification failed"))?;
         Ok(vcfrags_backend
             .iter()
             .map(|vcfrag| VerifiedCapsuleFrag {

--- a/nucypher-core-wasm/src/lib.rs
+++ b/nucypher-core-wasm/src/lib.rs
@@ -19,7 +19,7 @@ use core::fmt;
 use js_sys::Error;
 use nucypher_core::k256::ecdsa::recoverable;
 use nucypher_core::k256::ecdsa::signature::Signature as SignatureTrait;
-use nucypher_core::{ProtocolObject, ADDRESS_SIZE};
+use nucypher_core::ProtocolObject;
 use serde::{Deserialize, Serialize};
 use umbral_pre::bindings_wasm::{
     Capsule, PublicKey, SecretKey, Signer, VerifiedCapsuleFrag, VerifiedKeyFrag,
@@ -62,7 +62,7 @@ fn try_make_address(address_bytes: &[u8]) -> Result<nucypher_core::Address, JsVa
             JsValue::from(Error::new(&format!(
                 "Incorrect address size: {}, expected {}",
                 address_bytes.len(),
-                ADDRESS_SIZE
+                nucypher_core::Address::SIZE
             )))
         })
 }

--- a/nucypher-core-wasm/src/lib.rs
+++ b/nucypher-core-wasm/src/lib.rs
@@ -1247,9 +1247,9 @@ impl MetadataResponse {
     #[wasm_bindgen]
     pub fn verify(&self, verifying_pk: &PublicKey) -> Result<MetadataResponsePayload, JsValue> {
         self.0
+            .clone()
             .verify(verifying_pk.inner())
-            .ok_or("Invalid signature")
-            .map_err(map_js_err)
+            .map_err(|_err| Error::new("Failed to verify MetadataResponse").into())
             .map(MetadataResponsePayload)
     }
 

--- a/nucypher-core-wasm/src/lib.rs
+++ b/nucypher-core-wasm/src/lib.rs
@@ -194,7 +194,7 @@ impl HRAC {
 
     #[wasm_bindgen(js_name = fromBytes)]
     pub fn from_bytes(bytes: &[u8]) -> Result<HRAC, JsValue> {
-        let bytes: [u8; 16] = bytes.try_into().map_err(map_js_err)?;
+        let bytes: [u8; nucypher_core::HRAC::SIZE] = bytes.try_into().map_err(map_js_err)?;
         Ok(Self(bytes.into()))
     }
 

--- a/nucypher-core-wasm/src/lib.rs
+++ b/nucypher-core-wasm/src/lib.rs
@@ -670,7 +670,9 @@ impl ReencryptionResponseWithCapsules {
                 policy_encrypting_key.inner(),
                 bob_encrypting_key.inner(),
             )
-            .ok_or_else(|| JsValue::from_str("ReencryptionResponse verification failed"))?;
+            .map_err(|_err| {
+                JsValue::from(Error::new("ReencryptionResponse verification failed"))
+            })?;
 
         let vcfrags_backend_js = vcfrags_backend
             .iter()

--- a/nucypher-core-wasm/tests/wasm.rs
+++ b/nucypher-core-wasm/tests/wasm.rs
@@ -523,7 +523,7 @@ fn revocation_order() {
     let ursula_address = b"00000000000000000001";
     let revocation_order = RevocationOrder::new(&signer, ursula_address, &encrypted_kfrag).unwrap();
 
-    assert!(revocation_order.verify_signature(&delegating_sk.public_key()));
+    assert!(revocation_order.verify(&delegating_sk.public_key()).is_ok());
 
     let as_bytes = revocation_order.to_bytes();
     assert_eq!(

--- a/nucypher-core/src/address.rs
+++ b/nucypher-core/src/address.rs
@@ -13,16 +13,16 @@ use crate::arrays_as_bytes;
 // So for simplicity we just use our own type since we only need the size check.
 // Later a conversion method can be easily defined to/from `ethereum_types::Address`.
 
-/// Size of canonical Ethereum address, in bytes.
-pub const ADDRESS_SIZE: usize = 20;
-
 /// Represents an Ethereum address (20 bytes).
 #[derive(PartialEq, Debug, Serialize, Deserialize, Copy, Clone, PartialOrd, Eq, Ord)]
-pub struct Address(#[serde(with = "arrays_as_bytes")] [u8; ADDRESS_SIZE]);
+pub struct Address(#[serde(with = "arrays_as_bytes")] [u8; Address::SIZE]);
 
 impl Address {
+    /// Size of canonical Ethereum address, in bytes.
+    pub const SIZE: usize = 20;
+
     /// Creates an address from a fixed-length array.
-    pub fn new(bytes: &[u8; ADDRESS_SIZE]) -> Self {
+    pub fn new(bytes: &[u8; Self::SIZE]) -> Self {
         Self(*bytes)
     }
 

--- a/nucypher-core/src/address.rs
+++ b/nucypher-core/src/address.rs
@@ -44,3 +44,9 @@ impl AsRef<[u8]> for Address {
         self.0.as_ref()
     }
 }
+
+impl From<Address> for [u8; Address::SIZE] {
+    fn from(address: Address) -> [u8; Address::SIZE] {
+        address.0
+    }
+}

--- a/nucypher-core/src/hrac.rs
+++ b/nucypher-core/src/hrac.rs
@@ -18,9 +18,12 @@ use crate::arrays_as_bytes;
 /// Ursula does not, so we share it with her.
 #[allow(clippy::upper_case_acronyms)]
 #[derive(PartialEq, Debug, Copy, Clone, Serialize, Deserialize)]
-pub struct HRAC(#[serde(with = "arrays_as_bytes")] [u8; 16]);
+pub struct HRAC(#[serde(with = "arrays_as_bytes")] [u8; HRAC::SIZE]);
 
 impl HRAC {
+    /// The size of HRAC in bytes.
+    pub const SIZE: usize = 16;
+
     /// Creates a new HRAC.
     pub fn new(
         publisher_verifying_key: &PublicKey,
@@ -39,8 +42,8 @@ impl HRAC {
     }
 }
 
-impl From<[u8; 16]> for HRAC {
-    fn from(bytes: [u8; 16]) -> Self {
+impl From<[u8; HRAC::SIZE]> for HRAC {
+    fn from(bytes: [u8; HRAC::SIZE]) -> Self {
         Self(bytes)
     }
 }

--- a/nucypher-core/src/key_frag.rs
+++ b/nucypher-core/src/key_frag.rs
@@ -33,11 +33,7 @@ impl AuthorizedKeyFrag {
         Self { signature, kfrag }
     }
 
-    pub fn verify(
-        &self,
-        hrac: &HRAC,
-        publisher_verifying_key: &PublicKey,
-    ) -> Option<VerifiedKeyFrag> {
+    fn verify(&self, hrac: &HRAC, publisher_verifying_key: &PublicKey) -> Option<VerifiedKeyFrag> {
         if !self.signature.verify(
             publisher_verifying_key,
             &[hrac.as_ref(), self.kfrag.to_array().as_ref()].concat(),

--- a/nucypher-core/src/lib.rs
+++ b/nucypher-core/src/lib.rs
@@ -20,7 +20,7 @@ mod revocation_order;
 mod treasure_map;
 mod versioning;
 
-pub use address::{Address, ADDRESS_SIZE};
+pub use address::Address;
 pub use fleet_state::FleetStateChecksum;
 pub use hrac::HRAC;
 pub use key_frag::EncryptedKeyFrag;

--- a/nucypher-core/src/lib.rs
+++ b/nucypher-core/src/lib.rs
@@ -20,6 +20,9 @@ mod revocation_order;
 mod treasure_map;
 mod versioning;
 
+/// Error returned by various `verify()` methods in the crate.
+pub struct VerificationError;
+
 pub use address::Address;
 pub use fleet_state::FleetStateChecksum;
 pub use hrac::HRAC;

--- a/nucypher-core/src/node_metadata.rs
+++ b/nucypher-core/src/node_metadata.rs
@@ -273,14 +273,14 @@ impl MetadataResponse {
     }
 
     /// Verifies the metadata response and returns the contained payload.
-    pub fn verify(&self, verifying_pk: &PublicKey) -> Option<MetadataResponsePayload> {
+    pub fn verify(self, verifying_pk: &PublicKey) -> Result<MetadataResponsePayload, ()> {
         if self
             .signature
             .verify(verifying_pk, &self.payload.to_bytes())
         {
-            Some(self.payload.clone())
+            Ok(self.payload)
         } else {
-            None
+            Err(())
         }
     }
 }

--- a/nucypher-core/src/node_metadata.rs
+++ b/nucypher-core/src/node_metadata.rs
@@ -153,6 +153,8 @@ impl NodeMetadata {
         // This method returns bool and not NodeMetadataPayload,
         // because NodeMetadata can be used before verification,
         // so we need access to its fields right away.
+        // This may change depending on the decision in
+        // https://github.com/nucypher/nucypher/issues/2876
 
         // We could do this on deserialization, but it is a relatively expensive operation.
         self.signature

--- a/nucypher-core/src/node_metadata.rs
+++ b/nucypher-core/src/node_metadata.rs
@@ -15,6 +15,7 @@ use crate::fleet_state::FleetStateChecksum;
 use crate::versioning::{
     messagepack_deserialize, messagepack_serialize, ProtocolObject, ProtocolObjectInner,
 };
+use crate::VerificationError;
 
 impl SerializeAsBytes for recoverable::Signature {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -275,14 +276,17 @@ impl MetadataResponse {
     }
 
     /// Verifies the metadata response and returns the contained payload.
-    pub fn verify(self, verifying_pk: &PublicKey) -> Result<MetadataResponsePayload, ()> {
+    pub fn verify(
+        self,
+        verifying_pk: &PublicKey,
+    ) -> Result<MetadataResponsePayload, VerificationError> {
         if self
             .signature
             .verify(verifying_pk, &self.payload.to_bytes())
         {
             Ok(self.payload)
         } else {
-            Err(())
+            Err(VerificationError)
         }
     }
 }

--- a/nucypher-core/src/revocation_order.rs
+++ b/nucypher-core/src/revocation_order.rs
@@ -11,10 +11,10 @@ use crate::versioning::{
 };
 
 /// Represents a string used by characters to perform a revocation on a specific Ursula.
-#[derive(PartialEq, Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
 pub struct RevocationOrder {
     /// The address of the Ursula that is being revoked.
-    pub staking_provider_address: Address,
+    staking_provider_address: Address,
     encrypted_kfrag: EncryptedKeyFrag,
     signature: Signature,
 }
@@ -40,14 +40,21 @@ impl RevocationOrder {
     }
 
     /// Verifies the revocation order against Alice's key.
-    pub fn verify_signature(&self, alice_verifying_key: &PublicKey) -> bool {
-        // TODO: return an Option of something instead of returning `bool`?
+    /// On success, returns the staking provider address and the encrypted keyfrag.
+    pub fn verify(
+        self,
+        alice_verifying_key: &PublicKey,
+    ) -> Result<(Address, EncryptedKeyFrag), ()> {
         let message = [
             self.staking_provider_address.as_ref(),
             &self.encrypted_kfrag.to_bytes(),
         ]
         .concat();
-        self.signature.verify(alice_verifying_key, &message)
+        if self.signature.verify(alice_verifying_key, &message) {
+            Ok((self.staking_provider_address, self.encrypted_kfrag))
+        } else {
+            Err(())
+        }
     }
 }
 

--- a/nucypher-core/src/revocation_order.rs
+++ b/nucypher-core/src/revocation_order.rs
@@ -9,6 +9,7 @@ use crate::key_frag::EncryptedKeyFrag;
 use crate::versioning::{
     messagepack_deserialize, messagepack_serialize, ProtocolObject, ProtocolObjectInner,
 };
+use crate::VerificationError;
 
 /// Represents a string used by characters to perform a revocation on a specific Ursula.
 #[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
@@ -44,7 +45,7 @@ impl RevocationOrder {
     pub fn verify(
         self,
         alice_verifying_key: &PublicKey,
-    ) -> Result<(Address, EncryptedKeyFrag), ()> {
+    ) -> Result<(Address, EncryptedKeyFrag), VerificationError> {
         let message = [
             self.staking_provider_address.as_ref(),
             &self.encrypted_kfrag.to_bytes(),
@@ -53,7 +54,7 @@ impl RevocationOrder {
         if self.signature.verify(alice_verifying_key, &message) {
             Ok((self.staking_provider_address, self.encrypted_kfrag))
         } else {
-            Err(())
+            Err(VerificationError)
         }
     }
 }


### PR DESCRIPTION
- added a `HRAC::SIZE` constant and moved `ADDRESS_SIZE` to `Address::SIZE`
- added `HRAC.from_bytes()` in Python bindings to match WASM bindings
- renamed `RevocationOrder::verify_signature()` into `verify()` and made it return a Result<(Address, EncryptedKeyFrag)>. Correspondingly, made `RevocationOrder.staking_provider_address` private.
- made `MetadataResponse::verify()` and `ReencryptionResponse::verify()` return a `Result` instead of `Option`
- added `VerificationError` for the use of verification methods above