### PR TITLE
Add `Display` impl for `HRAC` and `FleetStateChecksum`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Eq` marker for `HRAC` and `FleetStateChecksum`. ([#17])
 - Python typing stubs. ([#20])
-- The Python module `nucypher_core.umbral` now exportd `KeyFrag`. ([#20])
+- The Python module `nucypher_core.umbral` now exports `KeyFrag`. ([#20])
+- `Display` impl for `HRAC` and `FleetStateChecksum`, and exposed it in the Python and WASM bindings. ([#22])
 
 
 [#17]: https://github.com/nucypher/nucypher-core/pull/17
 [#20]: https://github.com/nucypher/nucypher-core/pull/20
+[#22]: https://github.com/nucypher/nucypher-core/pull/22
 
 
 ## [0.2.0] - 2022-04-24

--- a/nucypher-core-python/src/lib.rs
+++ b/nucypher-core-python/src/lib.rs
@@ -195,6 +195,10 @@ impl HRAC {
     fn __hash__(&self) -> PyResult<isize> {
         hash("HRAC", self)
     }
+
+    fn __str__(&self) -> PyResult<String> {
+        Ok(format!("{}", self.backend))
+    }
 }
 
 impl AsBackend<nucypher_core::HRAC> for HRAC {
@@ -935,6 +939,10 @@ impl FleetStateChecksum {
 
     fn __hash__(&self) -> PyResult<isize> {
         hash("FleetStateChecksum", self)
+    }
+
+    fn __str__(&self) -> PyResult<String> {
+        Ok(format!("{}", self.backend))
     }
 }
 

--- a/nucypher-core-wasm/src/lib.rs
+++ b/nucypher-core-wasm/src/lib.rs
@@ -202,6 +202,12 @@ impl HRAC {
     pub fn to_bytes(&self) -> Box<[u8]> {
         self.0.as_ref().to_vec().into_boxed_slice()
     }
+
+    #[allow(clippy::inherent_to_string)]
+    #[wasm_bindgen(js_name = toString)]
+    pub fn to_string(&self) -> String {
+        format!("{}", self.0)
+    }
 }
 
 //
@@ -1066,6 +1072,12 @@ impl FleetStateChecksum {
     #[wasm_bindgen(js_name = toBytes)]
     pub fn to_bytes(&self) -> Box<[u8]> {
         self.0.as_ref().to_vec().into_boxed_slice()
+    }
+
+    #[allow(clippy::inherent_to_string)]
+    #[wasm_bindgen(js_name = toString)]
+    pub fn to_string(&self) -> String {
+        format!("{}", self.0)
     }
 }
 

--- a/nucypher-core/Cargo.toml
+++ b/nucypher-core/Cargo.toml
@@ -19,3 +19,4 @@ rmp-serde = "0.15"
 k256 = { version = "0.11", default-features = false, features = ["ecdsa"]}
 signature = "1.5"
 serde_with = "1.14"
+hex = "0.4"

--- a/nucypher-core/src/fleet_state.rs
+++ b/nucypher-core/src/fleet_state.rs
@@ -1,3 +1,5 @@
+use core::fmt;
+
 use serde::{Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
 use signature::digest::Update;
@@ -47,5 +49,12 @@ impl FleetStateChecksum {
 impl AsRef<[u8]> for FleetStateChecksum {
     fn as_ref(&self) -> &[u8] {
         self.0.as_ref()
+    }
+}
+
+impl fmt::Display for FleetStateChecksum {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let hex_repr = hex::encode(&self.0[..8]);
+        write!(f, "FleetStateChecksum:{}...", hex_repr)
     }
 }

--- a/nucypher-core/src/hrac.rs
+++ b/nucypher-core/src/hrac.rs
@@ -1,3 +1,5 @@
+use core::fmt;
+
 use generic_array::sequence::Split;
 use generic_array::GenericArray;
 use serde::{Deserialize, Serialize};
@@ -50,5 +52,12 @@ impl From<[u8; HRAC::SIZE]> for HRAC {
 impl AsRef<[u8]> for HRAC {
     fn as_ref(&self) -> &[u8] {
         self.0.as_ref()
+    }
+}
+
+impl fmt::Display for HRAC {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let hex_repr = hex::encode(&self.0[..8]);
+        write!(f, "HRAC:{}...", hex_repr)
     }
 }


### PR DESCRIPTION
- Add `Display` impl for `HRAC` and `FleetStateChecksum`
- Expose it in the bindings as `__str__()` for Python, and `toString()` for WASM