### PR TITLE
Small fixes after the introduction of conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Under Construction
+### Added
+
+- `conditions` getters in `MessageKit` and `RetrievalKit` in WASM bindings. (#[32])
+- Attributes `MessageKit.conditions`, `ReencryptionRequest.conditions`, and `ReencryptionRequest.context` in Python typing stubs. ([#32])
+
+
+[#32]: https://github.com/nucypher/nucypher-core/pull/32
 
 
 ## [0.4.0-alpha.0] - 2022-09-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Under Construction
 
-## [0.4.0-alpha.0] 2022-09-07
+
+## [0.4.0-alpha.0] - 2022-09-07
 
 ### Fixed
 
@@ -16,14 +17,14 @@ Under Construction
 
 ### Added
 
-- `conditions` and `context` to `ReencryptionRequest` with python/wasm bindings to expose them.
-- `conditions` to `MessageKit` and `RetrievalKit` with python/wasm bindings to expose them.
-- rust-native tests for these new attributes and getters
+- `conditions` and `context` to `ReencryptionRequest` with python/wasm bindings to expose them. ([#26])
+- `conditions` to `MessageKit` and `RetrievalKit` with python/wasm bindings to expose them. ([#26])
+- Rust-native tests for these new attributes and getters. ([#26])
 
-[#24]: https://github.com/nucypher/nucypher-core/pull/24
-[#25]: https://github.com/nucypher/nucypher-core/pull/25
+
 [#26]: https://github.com/nucypher/nucypher-core/pull/26
 [#28]: https://github.com/nucypher/nucypher-core/pull/28
+
 
 ## [0.3.0] - 2022-08-16
 
@@ -39,6 +40,7 @@ Under Construction
 - Python typing stubs. ([#20])
 - The Python module `nucypher_core.umbral` now exports `KeyFrag`. ([#20])
 - `Display` impl for `HRAC` and `FleetStateChecksum`, and exposed it in the Python and WASM bindings. ([#22])
+
 
 [#17]: https://github.com/nucypher/nucypher-core/pull/17
 [#20]: https://github.com/nucypher/nucypher-core/pull/20
@@ -109,6 +111,7 @@ Under Construction
 
 [#5]: https://github.com/nucypher/nucypher-core/pull/5
 
+
 ## [0.0.3] - 2022-02-03
 
 ### Fixed
@@ -136,6 +139,7 @@ Under Construction
 [#2]: https://github.com/nucypher/nucypher-core/pull/2
 [#4]: https://github.com/nucypher/nucypher-core/pull/4
 
+
 ## [0.0.1] - 2021-12-25
 
 Initial release.
@@ -150,3 +154,4 @@ Initial release.
 [0.1.1]: https://github.com/nucypher/nucypher-core/releases/tag/v0.1.1
 [0.2.0]: https://github.com/nucypher/nucypher-core/releases/tag/v0.2.0
 [0.3.0]: https://github.com/nucypher/nucypher-core/releases/tag/v0.3.0
+[0.4.0-alpha.0]: https://github.com/nucypher/nucypher-core/releases/tag/v0.4.0-alpha.0

--- a/nucypher-core-python/nucypher_core/__init__.pyi
+++ b/nucypher-core-python/nucypher_core/__init__.pyi
@@ -25,6 +25,8 @@ class MessageKit:
 
     capsule: Capsule
 
+    conditions: Optional[bytes]
+
 
 class HRAC:
 
@@ -145,6 +147,10 @@ class ReencryptionRequest:
     encrypted_kfrag: EncryptedKeyFrag
 
     capsules: List[Capsule]
+
+    conditions: Optional[bytes]
+
+    context: Optioanl[bytes]
 
     @staticmethod
     def from_bytes(data: bytes) -> ReencryptionRequest:

--- a/nucypher-core-python/src/lib.rs
+++ b/nucypher-core-python/src/lib.rs
@@ -78,6 +78,11 @@ where
     })
 }
 
+/// A simple adapter that unboxes a bytestring inside an `Option`.
+fn box_ref(source: &Option<Box<[u8]>>) -> Option<&[u8]> {
+    source.as_ref().map(|bytes| bytes.as_ref())
+}
+
 //
 //
 //
@@ -158,10 +163,7 @@ impl MessageKit {
 
     #[getter]
     fn conditions(&self) -> Option<&[u8]> {
-        self.backend
-            .conditions
-            .as_ref()
-            .map(|boxed_conditions| boxed_conditions.as_ref())
+        box_ref(&self.backend.conditions)
     }
 }
 
@@ -536,18 +538,12 @@ impl ReencryptionRequest {
 
     #[getter]
     fn conditions(&self) -> Option<&[u8]> {
-        self.backend
-            .conditions
-            .as_ref()
-            .map(|boxed_conditions| boxed_conditions.as_ref())
+        box_ref(&self.backend.conditions)
     }
 
     #[getter]
     fn context(&self) -> Option<&[u8]> {
-        self.backend
-            .context
-            .as_ref()
-            .map(|boxed_context| boxed_context.as_ref())
+        box_ref(&self.backend.context)
     }
 
     #[staticmethod]
@@ -709,10 +705,7 @@ impl RetrievalKit {
 
     #[getter]
     fn conditions(&self) -> Option<&[u8]> {
-        self.backend
-            .conditions
-            .as_ref()
-            .map(|boxed_conditions| boxed_conditions.as_ref())
+        box_ref(&self.backend.conditions)
     }
 
     #[staticmethod]

--- a/nucypher-core-python/src/lib.rs
+++ b/nucypher-core-python/src/lib.rs
@@ -161,7 +161,7 @@ impl MessageKit {
         self.backend
             .conditions
             .as_ref()
-            .map(|boxed_condition| boxed_condition.as_ref())
+            .map(|boxed_conditions| boxed_conditions.as_ref())
     }
 }
 
@@ -712,7 +712,7 @@ impl RetrievalKit {
         self.backend
             .conditions
             .as_ref()
-            .map(|boxed_condition| boxed_condition.as_ref())
+            .map(|boxed_conditions| boxed_conditions.as_ref())
     }
 
     #[staticmethod]

--- a/nucypher-core-wasm/src/lib.rs
+++ b/nucypher-core-wasm/src/lib.rs
@@ -70,6 +70,11 @@ fn try_make_address(address_bytes: &[u8]) -> Result<nucypher_core::Address, JsVa
         })
 }
 
+/// A simple adapter that unboxes a bytestring inside an `Option`.
+fn box_ref(source: &Option<Box<[u8]>>) -> Option<&[u8]> {
+    source.as_ref().map(|bytes| bytes.as_ref())
+}
+
 //
 // MessageKit
 //
@@ -96,12 +101,12 @@ impl MessageKit {
     pub fn new(
         policy_encrypting_key: &PublicKey,
         plaintext: &[u8],
-        conditions: Option<Vec<u8>>,
+        conditions: Option<Box<[u8]>>,
     ) -> MessageKit {
         MessageKit(nucypher_core::MessageKit::new(
             policy_encrypting_key.inner(),
             plaintext,
-            conditions.as_ref().map(|c| c.as_ref()),
+            box_ref(&conditions),
         ))
     }
 
@@ -530,10 +535,6 @@ impl ReencryptionRequestBuilder {
             box_ref(&self.context),
         ))
     }
-}
-
-fn box_ref(source: &Option<Box<[u8]>>) -> Option<&[u8]> {
-    source.as_ref().map(|bytes| bytes.as_ref())
 }
 
 #[wasm_bindgen]

--- a/nucypher-core-wasm/src/lib.rs
+++ b/nucypher-core-wasm/src/lib.rs
@@ -122,6 +122,11 @@ impl MessageKit {
         Capsule::new(self.0.capsule)
     }
 
+    #[wasm_bindgen(method, getter)]
+    pub fn conditions(&self) -> Option<Box<[u8]>> {
+        self.0.conditions.clone()
+    }
+
     #[wasm_bindgen(js_name = fromBytes)]
     pub fn from_bytes(data: &[u8]) -> Result<MessageKit, JsValue> {
         from_bytes(data)
@@ -809,6 +814,11 @@ impl RetrievalKit {
     #[wasm_bindgen(js_name = toBytes)]
     pub fn to_bytes(&self) -> Box<[u8]> {
         to_bytes(self)
+    }
+
+    #[wasm_bindgen(method, getter)]
+    pub fn conditions(&self) -> Option<Box<[u8]>> {
+        self.0.conditions.clone()
     }
 }
 


### PR DESCRIPTION
- use `box_ref()` throughout
- add missing `conditions` getters in WASM bindings
- add missing attribute declarations in Python typing stubs