### PR TITLE
Wrap conditions and context in newtypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Conditions and context are now strings instead of bytestrings. (#[33])
+- Methods taking `VerifiedCapsuleFrag` objects use "vcfrag" instead of "cfrag" for their names and the names of the corresponding parameters. (#[33])
+
+
 ### Added
 
 - `conditions` getters in `MessageKit` and `RetrievalKit` in WASM bindings. (#[32])
 - Attributes `MessageKit.conditions`, `ReencryptionRequest.conditions`, and `ReencryptionRequest.context` in Python typing stubs. ([#32])
+- `Conditions` and `Context` newtypes, to be used instead of raw objects. (#[33])
+- `MessageKit`, `RetrievalKit`, and `ReencryptionRequest` protocol versions bumped to v1.1. (#[33])
 
 
 [#32]: https://github.com/nucypher/nucypher-core/pull/32
+[#33]: https://github.com/nucypher/nucypher-core/pull/33
 
 
 ## [0.4.0-alpha.0] - 2022-09-07

--- a/nucypher-core-python/Cargo.toml
+++ b/nucypher-core-python/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib"]
 pyo3 = "0.16"
 nucypher-core = { path = "../nucypher-core" }
 umbral-pre = { version = "0.6", features = ["bindings-python", "serde-support"] }
+derive_more = { version = "0.99", default-features = false, features = ["from", "as_ref"] }
 
 [build-dependencies]
 pyo3-build-config = "*"

--- a/nucypher-core-python/nucypher_core/__init__.pyi
+++ b/nucypher-core-python/nucypher_core/__init__.pyi
@@ -19,7 +19,7 @@ class MessageKit:
         self,
         sk: SecretKey,
         policy_encrypting_key: PublicKey,
-        cfrags: Iterable[VerifiedCapsuleFrag]
+        vcfrags: Iterable[VerifiedCapsuleFrag]
     ) -> bytes:
         ...
 

--- a/nucypher-core-python/nucypher_core/__init__.pyi
+++ b/nucypher-core-python/nucypher_core/__init__.pyi
@@ -3,13 +3,44 @@ from typing import List, Dict, Iterable, Optional, Mapping, Tuple, Set
 from .umbral import SecretKey, PublicKey, Signer, Capsule, VerifiedKeyFrag, VerifiedCapsuleFrag
 
 
+class Conditions:
+
+    def __init__(self, conditions: str):
+        ...
+
+    @classmethod
+    def from_string(cls, conditions: str) -> Conditions:
+        ...
+
+    def __str__(self) -> str:
+        ...
+
+
+class Context:
+
+    def __init__(self, context: str):
+        ...
+
+    @classmethod
+    def from_string(cls, context: str) -> Context:
+        ...
+
+    def __str__(self) -> str:
+        ...
+
+
 class MessageKit:
 
     @staticmethod
     def from_bytes(data: bytes) -> MessageKit:
         ...
 
-    def __init__(self, policy_encrypting_key: PublicKey, plaintext: bytes):
+    def __init__(
+        self,
+        policy_encrypting_key: PublicKey,
+        plaintext: bytes,
+        conditions: Optional[Conditions]
+    ):
         ...
 
     def decrypt(self, sk: SecretKey) -> bytes:
@@ -25,7 +56,7 @@ class MessageKit:
 
     capsule: Capsule
 
-    conditions: Optional[bytes]
+    conditions: Optional[Conditions]
 
 
 class HRAC:
@@ -135,6 +166,8 @@ class ReencryptionRequest:
         encrypted_kfrag: EncryptedKeyFrag,
         publisher_verifying_key: PublicKey,
         bob_verifying_key: PublicKey,
+        conditions: Optional[Conditions],
+        context: Optional[Context],
     ):
         ...
 
@@ -148,9 +181,9 @@ class ReencryptionRequest:
 
     capsules: List[Capsule]
 
-    conditions: Optional[bytes]
+    conditions: Optional[Conditions]
 
-    context: Optioanl[bytes]
+    context: Optional[Context]
 
     @staticmethod
     def from_bytes(data: bytes) -> ReencryptionRequest:
@@ -193,6 +226,7 @@ class RetrievalKit:
         self,
         capsule: Capsule,
         queried_addresses: Set[bytes],
+        conditions: Optional[Conditions],
     ):
         ...
 
@@ -200,7 +234,7 @@ class RetrievalKit:
 
     queried_addresses: Set[bytes]
 
-    conditions: Optional[bytes]
+    conditions: Optional[Conditions]
 
     @staticmethod
     def from_bytes(data: bytes) -> RetrievalKit:

--- a/nucypher-core-python/src/lib.rs
+++ b/nucypher-core-python/src/lib.rs
@@ -256,7 +256,7 @@ impl EncryptedKeyFrag {
 //
 
 #[pyclass(module = "nucypher_core")]
-#[derive(Clone, PartialEq, derive_more::From, derive_more::AsRef)]
+#[derive(PartialEq, derive_more::From, derive_more::AsRef)]
 pub struct TreasureMap {
     backend: nucypher_core::TreasureMap,
 }

--- a/nucypher-core-python/src/lib.rs
+++ b/nucypher-core-python/src/lib.rs
@@ -143,13 +143,13 @@ impl MessageKit {
         py: Python,
         sk: &SecretKey,
         policy_encrypting_key: &PublicKey,
-        cfrags: Vec<VerifiedCapsuleFrag>,
+        vcfrags: Vec<VerifiedCapsuleFrag>,
     ) -> PyResult<PyObject> {
-        let backend_cfrags: Vec<umbral_pre::VerifiedCapsuleFrag> =
-            cfrags.into_iter().map(|vcfrag| vcfrag.backend).collect();
+        let backend_vcfrags: Vec<umbral_pre::VerifiedCapsuleFrag> =
+            vcfrags.into_iter().map(|vcfrag| vcfrag.backend).collect();
         let plaintext = self
             .backend
-            .decrypt_reencrypted(&sk.backend, &policy_encrypting_key.backend, backend_cfrags)
+            .decrypt_reencrypted(&sk.backend, &policy_encrypting_key.backend, backend_vcfrags)
             .map_err(|err| PyValueError::new_err(format!("{}", err)))?;
         Ok(PyBytes::new(py, &plaintext).into())
     }

--- a/nucypher-core-python/src/lib.rs
+++ b/nucypher-core-python/src/lib.rs
@@ -78,18 +78,20 @@ pub struct Conditions {
 #[pymethods]
 impl Conditions {
     #[new]
-    pub fn new(conditions: &[u8]) -> Self {
+    pub fn new(conditions: &str) -> Self {
         Self {
             backend: nucypher_core::Conditions::new(conditions),
         }
     }
 
     #[staticmethod]
-    pub fn from_bytes(data: &[u8]) -> Self {
-        Self::new(data)
+    pub fn from_string(conditions: String) -> Self {
+        Self {
+            backend: conditions.into(),
+        }
     }
 
-    fn __bytes__(&self) -> &[u8] {
+    fn __str__(&self) -> &str {
         self.backend.as_ref()
     }
 }
@@ -102,18 +104,20 @@ pub struct Context {
 #[pymethods]
 impl Context {
     #[new]
-    pub fn new(context: &[u8]) -> Self {
+    pub fn new(context: &str) -> Self {
         Self {
             backend: nucypher_core::Context::new(context),
         }
     }
 
     #[staticmethod]
-    pub fn from_bytes(data: &[u8]) -> Self {
-        Self::new(data)
+    pub fn from_bytes(context: String) -> Self {
+        Self {
+            backend: context.into(),
+        }
     }
 
-    fn __bytes__(&self) -> &[u8] {
+    fn __str__(&self) -> &str {
         self.backend.as_ref()
     }
 }

--- a/nucypher-core-wasm/Cargo.toml
+++ b/nucypher-core-wasm/Cargo.toml
@@ -28,6 +28,7 @@ ethereum-types = "0.12.1"
 serde-wasm-bindgen = "0.3.1"
 serde = { version = "1.0.130", features = ["derive"] }
 console_error_panic_hook = { version = "0.1.6", optional = true }
+derive_more = { version = "0.99", default-features = false, features = ["from", "as_ref"] }
 
 [dev-dependencies]
 console_error_panic_hook = "0.1.7"

--- a/nucypher-core-wasm/examples/node/src/main.test.ts
+++ b/nucypher-core-wasm/examples/node/src/main.test.ts
@@ -158,13 +158,13 @@ describe("MessageKit", () => {
     const capsule = Capsule.fromBytes(messageKit.capsule.toBytes());
     const capsuleFrags = vkfrags.map((kfrag) => reencrypt(capsule, kfrag));
 
-    const messageKitWithCfrags = messageKit.withCFrag(capsuleFrags[0]);
+    const messageKitWithVCfrags = messageKit.withVCFrag(capsuleFrags[0]);
     for (let i = 1; i < capsuleFrags.length; i++) {
-      messageKitWithCfrags.withCFrag(capsuleFrags[i]);
+      messageKitWithVCfrags.withVCFrag(capsuleFrags[i]);
     }
 
     // Decrypt the reencrypted message kit
-    const decrypted = messageKitWithCfrags.decryptReencrypted(
+    const decrypted = messageKitWithVCfrags.decryptReencrypted(
       recipientSk,
       delegatingPk
     );

--- a/nucypher-core-wasm/src/lib.rs
+++ b/nucypher-core-wasm/src/lib.rs
@@ -152,12 +152,12 @@ impl MessageKit {
         self.0.decrypt(sk.inner()).map_err(map_js_err)
     }
 
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(getter)]
     pub fn capsule(&self) -> Capsule {
         Capsule::new(self.0.capsule)
     }
 
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(getter)]
     pub fn conditions(&self) -> Option<Conditions> {
         self.0.conditions.clone().map(Conditions)
     }
@@ -363,7 +363,7 @@ impl TreasureMap {
         EncryptedTreasureMap(self.0.encrypt(signer.inner(), recipient_key.inner()))
     }
 
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(getter)]
     pub fn destinations(&self) -> Result<JsValue, JsValue> {
         let mut result = Vec::new();
         for (address, ekfrag) in &self.0.destinations {
@@ -377,26 +377,26 @@ impl TreasureMap {
         self.0
             .make_revocation_orders(signer.inner())
             .iter()
-            .map(|order| JsValue::from_serde(&order).unwrap())
+            .map(|order| serde_wasm_bindgen::to_value(&order).unwrap())
             .collect()
     }
 
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(getter)]
     pub fn hrac(&self) -> HRAC {
         HRAC(self.0.hrac)
     }
 
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(getter)]
     pub fn threshold(&self) -> u8 {
         self.0.threshold
     }
 
-    #[wasm_bindgen(method, getter, js_name = policyEncryptingKey)]
+    #[wasm_bindgen(getter, js_name = policyEncryptingKey)]
     pub fn policy_encrypting_key(&self) -> PublicKey {
         PublicKey::new(self.0.policy_encrypting_key)
     }
 
-    #[wasm_bindgen(method, getter, js_name = publisherVerifyingKey)]
+    #[wasm_bindgen(getter, js_name = publisherVerifyingKey)]
     pub fn publisher_verifying_key(&self) -> PublicKey {
         PublicKey::new(self.0.publisher_verifying_key)
     }
@@ -508,27 +508,27 @@ impl ReencryptionRequestBuilder {
 
 #[wasm_bindgen]
 impl ReencryptionRequest {
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(getter)]
     pub fn hrac(&self) -> HRAC {
         HRAC(self.0.hrac)
     }
 
-    #[wasm_bindgen(method, getter, js_name = publisherVerifyingKey)]
+    #[wasm_bindgen(getter, js_name = publisherVerifyingKey)]
     pub fn publisher_verifying_key(&self) -> PublicKey {
         PublicKey::new(self.0.publisher_verifying_key)
     }
 
-    #[wasm_bindgen(method, getter, js_name = bobVerifyingKey)]
+    #[wasm_bindgen(getter, js_name = bobVerifyingKey)]
     pub fn bob_verifying_key(&self) -> PublicKey {
         PublicKey::new(self.0.bob_verifying_key)
     }
 
-    #[wasm_bindgen(method, getter, js_name = encryptedKfrag)]
+    #[wasm_bindgen(getter, js_name = encryptedKfrag)]
     pub fn encrypted_kfrag(&self) -> EncryptedKeyFrag {
         EncryptedKeyFrag(self.0.encrypted_kfrag.clone())
     }
 
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(getter)]
     pub fn capsules(&self) -> Vec<JsValue> {
         self.0
             .capsules
@@ -548,12 +548,12 @@ impl ReencryptionRequest {
         to_bytes(self)
     }
 
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(getter)]
     pub fn conditions(&self) -> Option<Conditions> {
         self.0.conditions.clone().map(Conditions)
     }
 
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(getter)]
     pub fn context(&self) -> Option<Context> {
         self.0.context.clone().map(Context)
     }
@@ -677,7 +677,7 @@ impl ReencryptionResponseWithCapsules {
         let vcfrags_backend_js = vcfrags_backend
             .iter()
             .map(|vcfrag| VerifiedCapsuleFrag::new(vcfrag.clone()))
-            .map(|vcfrag| JsValue::from_serde(&vcfrag))
+            .map(|vcfrag| serde_wasm_bindgen::to_value(&vcfrag))
             .into_iter()
             .collect::<Result<Box<_>, _>>()
             .map_err(map_js_err)?;
@@ -738,17 +738,17 @@ impl RetrievalKit {
         ))
     }
 
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(getter)]
     pub fn capsule(&self) -> Capsule {
         Capsule::new(self.0.capsule)
     }
 
-    #[wasm_bindgen(method, getter, js_name = queriedAddresses)]
+    #[wasm_bindgen(getter, js_name = queriedAddresses)]
     pub fn queried_addresses(&self) -> Result<Vec<JsValue>, JsValue> {
         self.0
             .queried_addresses
             .iter()
-            .map(|address| JsValue::from_serde(&address))
+            .map(|address| serde_wasm_bindgen::to_value(&address))
             .into_iter()
             .collect::<Result<Vec<_>, _>>()
             .map_err(map_js_err)
@@ -764,7 +764,7 @@ impl RetrievalKit {
         to_bytes(self)
     }
 
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(getter)]
     pub fn conditions(&self) -> Option<Conditions> {
         self.0.conditions.clone().map(Conditions)
     }
@@ -888,49 +888,49 @@ impl NodeMetadataPayload {
         }))
     }
 
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(getter)]
     pub fn staking_provider_address(&self) -> Vec<u8> {
         self.0.staking_provider_address.as_ref().to_vec()
     }
 
-    #[wasm_bindgen(method, getter, js_name = verifyingKey)]
+    #[wasm_bindgen(getter, js_name = verifyingKey)]
     pub fn verifying_key(&self) -> PublicKey {
         PublicKey::new(self.0.verifying_key)
     }
 
-    #[wasm_bindgen(method, getter, js_name = encryptingKey)]
+    #[wasm_bindgen(getter, js_name = encryptingKey)]
     pub fn encrypting_key(&self) -> PublicKey {
         PublicKey::new(self.0.encrypting_key)
     }
 
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(getter)]
     pub fn operator_signature(&self) -> Option<Box<[u8]>> {
         self.0
             .operator_signature
             .map(|signature| signature.as_ref().into())
     }
 
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(getter)]
     pub fn domain(&self) -> String {
         self.0.domain.clone()
     }
 
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(getter)]
     pub fn host(&self) -> String {
         self.0.host.clone()
     }
 
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(getter)]
     pub fn port(&self) -> u16 {
         self.0.port
     }
 
-    #[wasm_bindgen(method, getter, js_name = timestampEpoch)]
+    #[wasm_bindgen(getter, js_name = timestampEpoch)]
     pub fn timestamp_epoch(&self) -> u32 {
         self.0.timestamp_epoch
     }
 
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(getter)]
     pub fn certificate_der(&self) -> Box<[u8]> {
         self.0.certificate_der.clone()
     }
@@ -965,7 +965,7 @@ impl NodeMetadata {
         self.0.verify()
     }
 
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(getter)]
     pub fn payload(&self) -> NodeMetadataPayload {
         NodeMetadataPayload(self.0.payload.clone())
     }
@@ -1099,12 +1099,12 @@ pub struct MetadataRequest(nucypher_core::MetadataRequest);
 
 #[wasm_bindgen]
 impl MetadataRequest {
-    #[wasm_bindgen(method, getter, js_name = fleetStateChecksum)]
+    #[wasm_bindgen(getter, js_name = fleetStateChecksum)]
     pub fn fleet_state_checksum(&self) -> FleetStateChecksum {
         FleetStateChecksum(self.0.fleet_state_checksum)
     }
 
-    #[wasm_bindgen(method, getter, js_name = announceNodes)]
+    #[wasm_bindgen(getter, js_name = announceNodes)]
     pub fn announce_nodes(&self) -> Vec<JsValue> {
         self.0
             .announce_nodes
@@ -1166,12 +1166,12 @@ pub struct MetadataResponsePayload(nucypher_core::MetadataResponsePayload);
 
 #[wasm_bindgen]
 impl MetadataResponsePayload {
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(getter)]
     pub fn timestamp_epoch(&self) -> u32 {
         self.0.timestamp_epoch
     }
 
-    #[wasm_bindgen(method, getter, js_name = announceNodes)]
+    #[wasm_bindgen(getter, js_name = announceNodes)]
     pub fn announce_nodes(&self) -> Vec<JsValue> {
         self.0
             .announce_nodes

--- a/nucypher-core-wasm/src/lib.rs
+++ b/nucypher-core-wasm/src/lib.rs
@@ -110,11 +110,11 @@ impl MessageKit {
         ))
     }
 
-    #[wasm_bindgen(js_name = withCFrag)]
-    pub fn with_cfrag(&self, cfrag: &VerifiedCapsuleFrag) -> MessageKitWithFrags {
+    #[wasm_bindgen(js_name = withVCFrag)]
+    pub fn with_vcfrag(&self, vcfrag: &VerifiedCapsuleFrag) -> MessageKitWithFrags {
         MessageKitWithFrags {
             message_kit: self.clone(),
-            cfrags: vec![cfrag.inner()],
+            vcfrags: vec![vcfrag.inner()],
         }
     }
 
@@ -147,14 +147,14 @@ impl MessageKit {
 #[derive(Clone)]
 pub struct MessageKitWithFrags {
     message_kit: MessageKit,
-    cfrags: Vec<umbral_pre::VerifiedCapsuleFrag>,
+    vcfrags: Vec<umbral_pre::VerifiedCapsuleFrag>,
 }
 
 #[wasm_bindgen]
 impl MessageKitWithFrags {
-    #[wasm_bindgen(js_name = withCFrag)]
-    pub fn with_cfrag(&mut self, cfrag: &VerifiedCapsuleFrag) -> MessageKitWithFrags {
-        self.cfrags.push(cfrag.inner());
+    #[wasm_bindgen(js_name = withVCFrag)]
+    pub fn with_vcfrag(&mut self, vcfrag: &VerifiedCapsuleFrag) -> MessageKitWithFrags {
+        self.vcfrags.push(vcfrag.inner());
         self.clone()
     }
 
@@ -169,7 +169,7 @@ impl MessageKitWithFrags {
             .decrypt_reencrypted(
                 sk.inner(),
                 policy_encrypting_key.inner(),
-                self.cfrags.clone(),
+                self.vcfrags.clone(),
             )
             .map_err(map_js_err)
     }

--- a/nucypher-core-wasm/src/lib.rs
+++ b/nucypher-core-wasm/src/lib.rs
@@ -76,7 +76,7 @@ fn box_ref(source: &Option<Box<[u8]>>) -> Option<&[u8]> {
 //
 
 #[wasm_bindgen]
-#[derive(PartialEq, Debug, Clone, derive_more::From, derive_more::AsRef)]
+#[derive(PartialEq, Debug, derive_more::From, derive_more::AsRef)]
 pub struct MessageKit(nucypher_core::MessageKit);
 
 #[wasm_bindgen]
@@ -97,7 +97,7 @@ impl MessageKit {
     #[wasm_bindgen(js_name = withVCFrag)]
     pub fn with_vcfrag(&self, vcfrag: &VerifiedCapsuleFrag) -> MessageKitWithFrags {
         MessageKitWithFrags {
-            message_kit: self.clone(),
+            message_kit: self.0.clone(),
             vcfrags: vec![vcfrag.inner()],
         }
     }
@@ -130,7 +130,7 @@ impl MessageKit {
 #[wasm_bindgen]
 #[derive(Clone)]
 pub struct MessageKitWithFrags {
-    message_kit: MessageKit,
+    message_kit: nucypher_core::MessageKit,
     vcfrags: Vec<umbral_pre::VerifiedCapsuleFrag>,
 }
 
@@ -149,7 +149,6 @@ impl MessageKitWithFrags {
         policy_encrypting_key: &PublicKey,
     ) -> Result<Box<[u8]>, JsValue> {
         self.message_kit
-            .0
             .decrypt_reencrypted(
                 sk.inner(),
                 policy_encrypting_key.inner(),

--- a/nucypher-core-wasm/src/lib.rs
+++ b/nucypher-core-wasm/src/lib.rs
@@ -77,17 +77,19 @@ pub struct Conditions(nucypher_core::Conditions);
 #[wasm_bindgen]
 impl Conditions {
     #[wasm_bindgen(constructor)]
-    pub fn new(conditions: &[u8]) -> Self {
+    pub fn new(conditions: &str) -> Self {
         Self(nucypher_core::Conditions::new(conditions))
     }
 
     #[wasm_bindgen(js_name = fromBytes)]
-    pub fn from_bytes(data: &[u8]) -> Self {
-        Self::new(data)
+    pub fn from_bytes(data: &str) -> Self {
+        let data_owned: String = data.into();
+        Self(nucypher_core::Conditions::from(data_owned))
     }
 
-    #[wasm_bindgen(js_name = toBytes)]
-    pub fn to_bytes(&self) -> Box<[u8]> {
+    #[allow(clippy::inherent_to_string)]
+    #[wasm_bindgen(js_name = toString)]
+    pub fn to_string(&self) -> String {
         self.0.as_ref().into()
     }
 }
@@ -98,17 +100,19 @@ pub struct Context(nucypher_core::Context);
 #[wasm_bindgen]
 impl Context {
     #[wasm_bindgen(constructor)]
-    pub fn new(context: &[u8]) -> Self {
+    pub fn new(context: &str) -> Self {
         Self(nucypher_core::Context::new(context))
     }
 
     #[wasm_bindgen(js_name = fromBytes)]
-    pub fn from_bytes(data: &[u8]) -> Self {
-        Self::new(data)
+    pub fn from_bytes(data: &str) -> Self {
+        let data_owned: String = data.into();
+        Self(nucypher_core::Context::from(data_owned))
     }
 
-    #[wasm_bindgen(js_name = toBytes)]
-    pub fn to_bytes(&self) -> Box<[u8]> {
+    #[allow(clippy::inherent_to_string)]
+    #[wasm_bindgen(js_name = toString)]
+    pub fn to_string(&self) -> String {
         self.0.as_ref().into()
     }
 }

--- a/nucypher-core-wasm/tests/wasm.rs
+++ b/nucypher-core-wasm/tests/wasm.rs
@@ -163,22 +163,22 @@ fn message_kit_decrypt_reencrypted() {
     );
 
     // Simulate reencryption on the JS side
-    let cfrags: Vec<VerifiedCapsuleFrag> = verified_kfrags
+    let vcfrags: Vec<VerifiedCapsuleFrag> = verified_kfrags
         .iter()
         .map(|kfrag| {
             let kfrag = verified_key_farg_of_js_value(kfrag.clone()).unwrap();
             reencrypt(&message_kit.capsule(), &kfrag)
         })
         .collect();
-    assert_eq!(cfrags.len(), verified_kfrags.len());
+    assert_eq!(vcfrags.len(), verified_kfrags.len());
 
-    let mut mk_with_cfrags = message_kit.with_cfrag(&cfrags[0]);
-    for cfrag in cfrags.iter().skip(1) {
-        mk_with_cfrags.with_cfrag(cfrag);
+    let mut mk_with_vcfrags = message_kit.with_vcfrag(&vcfrags[0]);
+    for vcfrag in vcfrags.iter().skip(1) {
+        mk_with_vcfrags.with_vcfrag(vcfrag);
     }
 
     // Decrypt on the Rust side
-    let decrypted = mk_with_cfrags
+    let decrypted = mk_with_vcfrags
         .decrypt_reencrypted(&receiving_sk, &delegating_pk)
         .unwrap();
 

--- a/nucypher-core-wasm/tests/wasm.rs
+++ b/nucypher-core-wasm/tests/wasm.rs
@@ -463,10 +463,11 @@ fn reencryption_response_verify() {
             &policy_encrypting_key,
             &bob_sk.public_key(),
         )
-        .unwrap();
+        .unwrap()
+        .into_vec();
     let verified: Vec<VerifiedCapsuleFrag> = verified_js
-        .iter()
-        .map(|vkfrag| vkfrag.into_serde().unwrap())
+        .into_iter()
+        .map(|vkfrag| serde_wasm_bindgen::from_value(vkfrag).unwrap())
         .collect();
 
     assert_eq!(cfrags, verified, "Capsule fragments do not match");

--- a/nucypher-core/src/conditions.rs
+++ b/nucypher-core/src/conditions.rs
@@ -1,0 +1,50 @@
+use alloc::boxed::Box;
+
+use serde::{Deserialize, Serialize};
+use umbral_pre::serde_bytes;
+
+/// Reencryption conditions.
+#[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
+pub struct Conditions(#[serde(with = "serde_bytes::as_base64")] Box<[u8]>);
+
+impl Conditions {
+    /// Creates a new conditions object.
+    pub fn new(conditions: &[u8]) -> Self {
+        Self(conditions.into())
+    }
+}
+
+impl AsRef<[u8]> for Conditions {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl From<Box<[u8]>> for Conditions {
+    fn from(source: Box<[u8]>) -> Self {
+        Self(source)
+    }
+}
+
+/// Context for reencryption conditions.
+#[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
+pub struct Context(#[serde(with = "serde_bytes::as_base64")] Box<[u8]>);
+
+impl Context {
+    /// Creates a new context object.
+    pub fn new(context: &[u8]) -> Self {
+        Self(context.into())
+    }
+}
+
+impl AsRef<[u8]> for Context {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl From<Box<[u8]>> for Context {
+    fn from(source: Box<[u8]>) -> Self {
+        Self(source)
+    }
+}

--- a/nucypher-core/src/conditions.rs
+++ b/nucypher-core/src/conditions.rs
@@ -1,50 +1,49 @@
-use alloc::boxed::Box;
+use alloc::string::String;
 
 use serde::{Deserialize, Serialize};
-use umbral_pre::serde_bytes;
 
 /// Reencryption conditions.
 #[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
-pub struct Conditions(#[serde(with = "serde_bytes::as_base64")] Box<[u8]>);
+pub struct Conditions(String);
 
 impl Conditions {
     /// Creates a new conditions object.
-    pub fn new(conditions: &[u8]) -> Self {
+    pub fn new(conditions: &str) -> Self {
         Self(conditions.into())
     }
 }
 
-impl AsRef<[u8]> for Conditions {
-    fn as_ref(&self) -> &[u8] {
+impl AsRef<str> for Conditions {
+    fn as_ref(&self) -> &str {
         self.0.as_ref()
     }
 }
 
-impl From<Box<[u8]>> for Conditions {
-    fn from(source: Box<[u8]>) -> Self {
+impl From<String> for Conditions {
+    fn from(source: String) -> Self {
         Self(source)
     }
 }
 
 /// Context for reencryption conditions.
 #[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
-pub struct Context(#[serde(with = "serde_bytes::as_base64")] Box<[u8]>);
+pub struct Context(String);
 
 impl Context {
     /// Creates a new context object.
-    pub fn new(context: &[u8]) -> Self {
+    pub fn new(context: &str) -> Self {
         Self(context.into())
     }
 }
 
-impl AsRef<[u8]> for Context {
-    fn as_ref(&self) -> &[u8] {
+impl AsRef<str> for Context {
+    fn as_ref(&self) -> &str {
         self.0.as_ref()
     }
 }
 
-impl From<Box<[u8]>> for Context {
-    fn from(source: Box<[u8]>) -> Self {
+impl From<String> for Context {
+    fn from(source: String) -> Self {
         Self(source)
     }
 }

--- a/nucypher-core/src/lib.rs
+++ b/nucypher-core/src/lib.rs
@@ -8,6 +8,7 @@
 extern crate alloc;
 
 mod address;
+mod conditions;
 mod fleet_state;
 mod hrac;
 mod key_frag;
@@ -23,6 +24,7 @@ mod versioning;
 pub struct VerificationError;
 
 pub use address::Address;
+pub use conditions::{Conditions, Context};
 pub use fleet_state::FleetStateChecksum;
 pub use hrac::HRAC;
 pub use key_frag::EncryptedKeyFrag;

--- a/nucypher-core/src/message_kit.rs
+++ b/nucypher-core/src/message_kit.rs
@@ -54,13 +54,13 @@ impl MessageKit {
         &self,
         sk: &SecretKey,
         policy_encrypting_key: &PublicKey,
-        cfrags: impl IntoIterator<Item = VerifiedCapsuleFrag>,
+        vcfrags: impl IntoIterator<Item = VerifiedCapsuleFrag>,
     ) -> Result<Box<[u8]>, ReencryptionError> {
         decrypt_reencrypted(
             sk,
             policy_encrypting_key,
             &self.capsule,
-            cfrags,
+            vcfrags,
             self.ciphertext.clone(),
         )
     }

--- a/nucypher-core/src/message_kit.rs
+++ b/nucypher-core/src/message_kit.rs
@@ -7,6 +7,7 @@ use umbral_pre::{
     EncryptionError, PublicKey, ReencryptionError, SecretKey, VerifiedCapsuleFrag,
 };
 
+use crate::conditions::Conditions;
 use crate::versioning::{
     messagepack_deserialize, messagepack_serialize, ProtocolObject, ProtocolObjectInner,
 };
@@ -18,8 +19,8 @@ pub struct MessageKit {
     pub capsule: Capsule,
     #[serde(with = "serde_bytes::as_base64")]
     ciphertext: Box<[u8]>,
-    /// A blob of bytes containing decryption conditions for this message.
-    pub conditions: Option<Box<[u8]>>,
+    /// Decryption conditions for this message.
+    pub conditions: Option<Conditions>,
 }
 
 impl MessageKit {
@@ -27,7 +28,7 @@ impl MessageKit {
     pub fn new(
         policy_encrypting_key: &PublicKey,
         plaintext: &[u8],
-        conditions: Option<&[u8]>,
+        conditions: Option<&Conditions>,
     ) -> Self {
         let (capsule, ciphertext) = match encrypt(policy_encrypting_key, plaintext) {
             Ok(result) => result,
@@ -40,7 +41,7 @@ impl MessageKit {
         Self {
             capsule,
             ciphertext,
-            conditions: conditions.map(|c| c.into()),
+            conditions: conditions.cloned(),
         }
     }
 

--- a/nucypher-core/src/reencryption.rs
+++ b/nucypher-core/src/reencryption.rs
@@ -234,13 +234,13 @@ mod tests {
             &encrypted_kfrag,
             &some_trinket,
             &another_trinket,
-            Some(&Conditions::new(&[47u8])),
-            Some(&Context::new(&[51u8])),
+            Some(&Conditions::new("abcd")),
+            Some(&Context::new("efgh")),
         );
         let conditions = request.conditions.unwrap();
-        assert!(conditions.as_ref()[0].eq(&47u8));
+        assert_eq!(conditions.as_ref(), "abcd");
 
         let context = request.context.unwrap();
-        assert!(context.as_ref()[0].eq(&51u8));
+        assert_eq!(context.as_ref(), "efgh");
     }
 }

--- a/nucypher-core/src/retrieval_kit.rs
+++ b/nucypher-core/src/retrieval_kit.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use umbral_pre::Capsule;
 
 use crate::address::Address;
+use crate::conditions::Conditions;
 use crate::message_kit::MessageKit;
 use crate::versioning::{
     messagepack_deserialize, messagepack_serialize, ProtocolObject, ProtocolObjectInner,
@@ -21,7 +22,7 @@ pub struct RetrievalKit {
     /// The addresses that have already been queried for reencryption.
     pub queried_addresses: BTreeSet<Address>,
     /// A blob of bytes containing decryption conditions for this message.
-    pub conditions: Option<Box<[u8]>>,
+    pub conditions: Option<Conditions>,
 }
 
 impl RetrievalKit {
@@ -38,13 +39,13 @@ impl RetrievalKit {
     pub fn new(
         capsule: &Capsule,
         queried_addresses: impl IntoIterator<Item = Address>,
-        conditions: Option<&[u8]>,
+        conditions: Option<&Conditions>,
     ) -> Self {
         // Can store cfrags too, if we're worried about Ursulas supplying duplicate ones.
         Self {
             capsule: *capsule,
             queried_addresses: queried_addresses.into_iter().collect(),
-            conditions: conditions.map(|c| c.into()),
+            conditions: conditions.cloned(),
         }
     }
 }


### PR DESCRIPTION
- Added `Context` and `Conditions` newtypes. 
- Changed context and conditions to be strings instead of bytes.
- Support v1.0 (pre-conditions) `MessageKit`, `RetrievalKit` and `ReencryptionRequest`
- Some internal boilerplate removal (get rid of `AsBackend` and `FromBackend` and replace them with derived `AsRef` and `From`)

**Note:** because of a strange quirk of wasm-bindgen (https://github.com/rustwasm/wasm-bindgen/issues/2370) constructors taking `Option<Conditions>` or `Option<Context>` consume their arguments in JS. This is already an issue in Umbral (https://github.com/nucypher/rust-umbral/issues/25). 