### PR TITLE
Bindings simplification

### DIFF
--- a/.github/workflows/nucypher-core.yml
+++ b/.github/workflows/nucypher-core.yml
@@ -66,6 +66,36 @@ jobs:
       - run: cargo install wasm-pack
       - run: wasm-pack test --node
 
+  yarn-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+        target:
+          - wasm32-unknown-unknown
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
+          override: true
+      - run: cargo install wasm-pack
+      - run: make
+        working-directory: nucypher-core-wasm
+      - uses: borales/actions-yarn@v3.0.0
+        with:
+          cmd: --cwd nucypher-core-wasm/examples/node install
+      - uses: borales/actions-yarn@v3.0.0
+        with:
+          cmd: --cwd nucypher-core-wasm/examples/node build
+      - uses: borales/actions-yarn@v3.0.0
+        with:
+          cmd: --cwd nucypher-core-wasm/examples/node test
+
   trigger-wheels:
     runs-on: ubuntu-latest
     needs: test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Conditions and context are now strings instead of bytestrings. (#[33])
 - Methods taking `VerifiedCapsuleFrag` objects use "vcfrag" instead of "cfrag" for their names and the names of the corresponding parameters. (#[33])
+- Use a workaround with `wasm-bindgen-derive` to support `Option<&T>` and `Vec<&T>` arguments, and `Vec<T>` and tuple return values, with correct TypeScript annotations. Removed all the Builder pattern helper classes. (#[34])
+- Use `Address` instead of plain bytes in arguments and return values (both in WASM and Python bindgins). Export the `Address` type. (#[34])
 
 
 ### Added
@@ -20,8 +22,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `MessageKit`, `RetrievalKit`, and `ReencryptionRequest` protocol versions bumped to v1.1. (#[33])
 
 
+### Fixed
+
+- Removed `serde` dependency for WASM bindings. (#[34])
+
+
 [#32]: https://github.com/nucypher/nucypher-core/pull/32
 [#33]: https://github.com/nucypher/nucypher-core/pull/33
+[#34]: https://github.com/nucypher/nucypher-core/pull/34
 
 
 ## [0.4.0-alpha.0] - 2022-09-07

--- a/nucypher-core-python/Cargo.toml
+++ b/nucypher-core-python/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3 = "0.16"
 nucypher-core = { path = "../nucypher-core" }
-umbral-pre = { version = "0.7.0-alpha.0", features = ["bindings-python", "serde-support"] }
+umbral-pre = { version = "0.7.0-alpha.0", features = ["bindings-python"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "as_ref"] }
 
 [build-dependencies]

--- a/nucypher-core-python/Cargo.toml
+++ b/nucypher-core-python/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3 = "0.16"
 nucypher-core = { path = "../nucypher-core" }
-umbral-pre = { version = "0.6", features = ["bindings-python", "serde-support"] }
+umbral-pre = { version = "0.7.0-alpha.0", features = ["bindings-python", "serde-support"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "as_ref"] }
 
 [build-dependencies]

--- a/nucypher-core-python/nucypher_core/__init__.py
+++ b/nucypher-core-python/nucypher_core/__init__.py
@@ -1,6 +1,7 @@
 from ._nucypher_core import (
     Conditions,
     Context,
+    Address,
     MessageKit,
     HRAC,
     EncryptedKeyFrag,

--- a/nucypher-core-python/nucypher_core/__init__.pyi
+++ b/nucypher-core-python/nucypher_core/__init__.pyi
@@ -3,6 +3,21 @@ from typing import List, Dict, Iterable, Optional, Mapping, Tuple, Set
 from .umbral import SecretKey, PublicKey, Signer, Capsule, VerifiedKeyFrag, VerifiedCapsuleFrag
 
 
+class Address:
+
+    def __init__(self, address_bytes: bytes):
+        ...
+
+    def __bytes__(self) -> bytes:
+        ...
+
+    def __hash__(self) -> int:
+        ...
+
+    def __eq__(self, other) -> bool:
+        ...
+
+
 class Conditions:
 
     def __init__(self, conditions: str):
@@ -111,7 +126,7 @@ class TreasureMap:
         signer: Signer,
         hrac: HRAC,
         policy_encrypting_key: PublicKey,
-        assigned_kfrags: Mapping[bytes, Tuple[PublicKey, VerifiedKeyFrag]],
+        assigned_kfrags: Mapping[Address, Tuple[PublicKey, VerifiedKeyFrag]],
         threshold: int,
     ):
         ...
@@ -122,7 +137,7 @@ class TreasureMap:
     def make_revocation_orders(self, signer: Signer) -> List[RevocationOrder]:
         ...
 
-    destinations: Dict[bytes, EncryptedKeyFrag]
+    destinations: Dict[Address, EncryptedKeyFrag]
 
     hrac: HRAC
 
@@ -225,14 +240,14 @@ class RetrievalKit:
     def __init__(
         self,
         capsule: Capsule,
-        queried_addresses: Set[bytes],
+        queried_addresses: Set[Address],
         conditions: Optional[Conditions],
     ):
         ...
 
     capsule: Capsule
 
-    queried_addresses: Set[bytes]
+    queried_addresses: Set[Address]
 
     conditions: Optional[Conditions]
 
@@ -249,7 +264,7 @@ class RevocationOrder:
     def __init__(
         self,
         signer: Signer,
-        staking_provider_address: bytes,
+        staking_provider_address: Address,
         encrypted_kfrag: EncryptedKeyFrag,
     ):
         ...
@@ -257,7 +272,7 @@ class RevocationOrder:
     def verify(
         self,
         alice_verifying_key: PublicKey,
-    ) -> Tuple[bytes, EncryptedKeyFrag]:
+    ) -> Tuple[Address, EncryptedKeyFrag]:
         ...
 
     @staticmethod
@@ -272,7 +287,7 @@ class NodeMetadataPayload:
 
     def __init__(
         self,
-        staking_provider_address: bytes,
+        staking_provider_address: Address,
         domain: str,
         timestamp_epoch: int,
         verifying_key: PublicKey,
@@ -284,7 +299,7 @@ class NodeMetadataPayload:
     ):
         ...
 
-    staking_provider_address: bytes
+    staking_provider_address: Address
 
     verifying_key: PublicKey
 
@@ -302,7 +317,7 @@ class NodeMetadataPayload:
 
     certificate_der: bytes
 
-    def derive_operator_address(self) -> bytes:
+    def derive_operator_address(self) -> Address:
         ...
 
 

--- a/nucypher-core-python/src/lib.rs
+++ b/nucypher-core-python/src/lib.rs
@@ -43,13 +43,13 @@ where
         .map_err(|err| PyValueError::new_err(format!("Failed to deserialize: {}", err)))
 }
 
-fn richcmp<T>(obj: &T, other: PyRef<'_, T>, op: CompareOp) -> PyResult<bool>
+fn richcmp<T>(obj: &T, other: &T, op: CompareOp) -> PyResult<bool>
 where
     T: PyClass + PartialEq,
 {
     match op {
-        CompareOp::Eq => Ok(obj == &*other),
-        CompareOp::Ne => Ok(obj != &*other),
+        CompareOp::Eq => Ok(obj == other),
+        CompareOp::Ne => Ok(obj != other),
         _ => Err(PyTypeError::new_err("Objects are not ordered")),
     }
 }
@@ -89,7 +89,7 @@ impl Address {
         self.backend.as_ref()
     }
 
-    fn __richcmp__(&self, other: PyRef<'_, Address>, op: CompareOp) -> PyResult<bool> {
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {
         richcmp(self, other, op)
     }
 
@@ -265,7 +265,7 @@ impl HRAC {
         self.backend.as_ref()
     }
 
-    fn __richcmp__(&self, other: PyRef<HRAC>, op: CompareOp) -> PyResult<bool> {
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {
         richcmp(self, other, op)
     }
 
@@ -927,7 +927,7 @@ impl FleetStateChecksum {
         self.backend.as_ref()
     }
 
-    fn __richcmp__(&self, other: PyRef<FleetStateChecksum>, op: CompareOp) -> PyResult<bool> {
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {
         richcmp(self, other, op)
     }
 

--- a/nucypher-core-wasm/Cargo.toml
+++ b/nucypher-core-wasm/Cargo.toml
@@ -21,14 +21,13 @@ default = ["console_error_panic_hook"]
 [dependencies]
 umbral-pre = { version = "0.7.0-alpha.0", features = ["bindings-wasm"] }
 nucypher-core = { path = "../nucypher-core" }
-wasm-bindgen = { version = "0.2.74", features = ["serde-serialize"] }
+wasm-bindgen = "0.2.74"
 js-sys = "0.3.51"
 wee_alloc = "0.4"
 ethereum-types = "0.12.1"
-serde-wasm-bindgen = "0.3.1"
-serde = { version = "1.0.130", features = ["derive"] }
 console_error_panic_hook = { version = "0.1.6", optional = true }
 derive_more = { version = "0.99", default-features = false, features = ["from", "as_ref"] }
+wasm-bindgen-derive = "0.1"
 
 [dev-dependencies]
 console_error_panic_hook = "0.1.7"

--- a/nucypher-core-wasm/Cargo.toml
+++ b/nucypher-core-wasm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-umbral-pre = { version = "0.6", features = ["bindings-wasm"] }
+umbral-pre = { version = "0.7.0-alpha.0", features = ["bindings-wasm"] }
 nucypher-core = { path = "../nucypher-core" }
 wasm-bindgen = { version = "0.2.74", features = ["serde-serialize"] }
 js-sys = "0.3.51"

--- a/nucypher-core-wasm/examples/node/src/main.ts
+++ b/nucypher-core-wasm/examples/node/src/main.ts
@@ -6,7 +6,7 @@ export function run() {
   const delegatingPk = delegatingSk.publicKey();
   const message = new Uint8Array(Buffer.from("Hello"));
 
-  const messageKit = new MessageKit(delegatingPk, message);
+  const messageKit = new MessageKit(delegatingPk, message, null);
 
   const decrypted = messageKit.decrypt(delegatingSk);
   console.assert(

--- a/nucypher-core-wasm/src/lib.rs
+++ b/nucypher-core-wasm/src/lib.rs
@@ -2,7 +2,6 @@
 // Disable false-positive warnings caused by `#[wasm-bindgen]` on struct impls
 #![allow(clippy::unused_unit)]
 
-#[macro_use]
 extern crate alloc;
 // Use `wee_alloc` as the global allocator.
 extern crate wee_alloc;
@@ -15,12 +14,13 @@ use alloc::{
 };
 use core::fmt;
 
-use js_sys::Error;
-use serde::{Deserialize, Serialize};
+use js_sys::{Error, Uint8Array};
 use umbral_pre::bindings_wasm::{
     Capsule, PublicKey, SecretKey, Signer, VerifiedCapsuleFrag, VerifiedKeyFrag,
 };
 use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
+use wasm_bindgen::JsCast;
+use wasm_bindgen_derive::TryFromJsValue;
 
 use nucypher_core::k256::ecdsa::recoverable;
 use nucypher_core::k256::ecdsa::signature::Signature as SignatureTrait;
@@ -29,8 +29,8 @@ use nucypher_core::ProtocolObject;
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
-fn map_js_err<T: fmt::Display>(err: T) -> JsValue {
-    Error::new(&format!("{}", err)).into()
+fn map_js_err<T: fmt::Display>(err: T) -> Error {
+    Error::new(&format!("{}", err))
 }
 
 fn to_bytes<'a, T, U>(obj: &T) -> Box<[u8]>
@@ -45,7 +45,7 @@ where
 // we will have to specify `U` explicitly when calling this function.
 // This could be avoided if a more specific "newtype" trait could be derived instead of `From`.
 // See https://github.com/JelteF/derive_more/issues/201
-fn from_bytes<'a, T, U>(data: &'a [u8]) -> Result<T, JsValue>
+fn from_bytes<'a, T, U>(data: &'a [u8]) -> Result<T, Error>
 where
     T: From<U>,
     U: ProtocolObject<'a>,
@@ -53,25 +53,87 @@ where
     U::from_bytes(data).map(T::from).map_err(map_js_err)
 }
 
-fn try_make_address(address_bytes: &[u8]) -> Result<nucypher_core::Address, JsValue> {
-    address_bytes
-        .try_into()
-        .map(nucypher_core::Address::new)
-        .map_err(|_err| {
-            JsValue::from(Error::new(&format!(
-                "Incorrect address size: {}, expected {}",
-                address_bytes.len(),
-                nucypher_core::Address::SIZE
-            )))
-        })
+/// Tries to convert an optional value (either `null` or a `#[wasm_bindgen]` marked structure)
+/// from `JsValue` to the Rust type.
+// TODO (rust-umbral#25): This is necessary since wasm-bindgen does not support
+// having a parameter of `Option<&T>`, and using `Option<T>` consumes the argument
+// (see https://github.com/rustwasm/wasm-bindgen/issues/2370).
+fn try_from_js_option<'a, T>(value: &'a JsValue) -> Result<Option<T>, Error>
+where
+    T: TryFrom<&'a JsValue>,
+    <T as TryFrom<&'a JsValue>>::Error: core::fmt::Display,
+{
+    let typed_value = if value.is_null() {
+        None
+    } else {
+        Some(T::try_from(value).map_err(map_js_err)?)
+    };
+    Ok(typed_value)
+}
+
+/// Tries to convert a JS array from `JsValue` to a vector of Rust type elements.
+// TODO (rust-umbral#23): This is necessary since wasm-bindgen does not support
+// having a parameter of `Vec<&T>`
+// (see https://github.com/rustwasm/wasm-bindgen/issues/111).
+fn try_from_js_array<T>(value: &JsValue) -> Result<Vec<T>, Error>
+where
+    for<'a> T: TryFrom<&'a JsValue>,
+    for<'a> <T as TryFrom<&'a JsValue>>::Error: core::fmt::Display,
+{
+    let array: &js_sys::Array = value
+        .dyn_ref()
+        .ok_or_else(|| Error::new("Got a non-array argument where an array was expected"))?;
+    let length: usize = array.length().try_into().map_err(map_js_err)?;
+    let mut result = Vec::<T>::with_capacity(length);
+    for js in array.iter() {
+        let typed_elem = T::try_from(&js).map_err(map_js_err)?;
+        result.push(typed_elem);
+    }
+    Ok(result)
+}
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "VerifiedCapsuleFrag[]")]
+    pub type VerifiedCapsuleFragArray;
+
+    #[wasm_bindgen(typescript_type = "Conditions | null")]
+    pub type OptionConditions;
+
+    #[wasm_bindgen(typescript_type = "Context | null")]
+    pub type OptionContext;
+
+    #[wasm_bindgen(typescript_type = "[Address, [PublicKey, VerifiedKeyFrag]][]")]
+    pub type AssignedKeyFragsArray;
+
+    #[wasm_bindgen(typescript_type = "[Address, EncryptedKeyFrag][]")]
+    pub type DestinationsArray;
+
+    #[wasm_bindgen(typescript_type = "Capsule[]")]
+    pub type CapsuleArray;
+
+    #[wasm_bindgen(typescript_type = "Address[]")]
+    pub type AddressArray;
+
+    #[wasm_bindgen(typescript_type = "NodeMetadata[]")]
+    pub type NodeMetadataArray;
+
+    #[wasm_bindgen(typescript_type = "NodeMetadata | null")]
+    pub type OptionNodeMetadata;
+
+    #[wasm_bindgen(typescript_type = "RevocationOrder | null")]
+    pub type RevocationOrderArray;
+
+    #[wasm_bindgen(typescript_type = "Uint8Array | null")]
+    pub type OptionUint8Array;
 }
 
 //
 // Conditions
 //
 
+#[derive(Clone, TryFromJsValue)]
 #[wasm_bindgen]
-#[derive(Clone)]
 pub struct Conditions(nucypher_core::Conditions);
 
 #[wasm_bindgen]
@@ -94,7 +156,9 @@ impl Conditions {
     }
 }
 
+#[derive(TryFromJsValue)]
 #[wasm_bindgen]
+#[derive(Clone)]
 pub struct Context(nucypher_core::Context);
 
 #[wasm_bindgen]
@@ -118,6 +182,42 @@ impl Context {
 }
 
 //
+// Address
+//
+
+#[derive(TryFromJsValue)]
+#[wasm_bindgen]
+#[derive(Clone, derive_more::AsRef, derive_more::From)]
+pub struct Address(nucypher_core::Address);
+
+#[wasm_bindgen]
+impl Address {
+    #[wasm_bindgen(constructor)]
+    pub fn new(address_bytes: &[u8]) -> Result<Address, Error> {
+        address_bytes
+            .try_into()
+            .map(nucypher_core::Address::new)
+            .map(Self)
+            .map_err(|_err| {
+                Error::new(&format!(
+                    "Incorrect address size: {}, expected {}",
+                    address_bytes.len(),
+                    nucypher_core::Address::SIZE
+                ))
+            })
+    }
+
+    #[wasm_bindgen(js_name = toBytes)]
+    pub fn to_bytes(&self) -> Box<[u8]> {
+        self.0.as_ref().to_vec().into_boxed_slice()
+    }
+
+    pub fn equals(&self, other: &Address) -> bool {
+        self.0 == other.0
+    }
+}
+
+//
 // MessageKit
 //
 
@@ -131,30 +231,23 @@ impl MessageKit {
     pub fn new(
         policy_encrypting_key: &PublicKey,
         plaintext: &[u8],
-        conditions: Option<Conditions>,
-    ) -> Self {
-        MessageKit(nucypher_core::MessageKit::new(
-            policy_encrypting_key.inner(),
+        conditions: &OptionConditions,
+    ) -> Result<MessageKit, Error> {
+        let typed_conditions = try_from_js_option::<Conditions>(conditions.as_ref())?;
+        Ok(MessageKit(nucypher_core::MessageKit::new(
+            policy_encrypting_key.as_ref(),
             plaintext,
-            conditions.as_ref().map(|conditions| &conditions.0),
-        ))
+            typed_conditions.as_ref().map(|c| &c.0),
+        )))
     }
 
-    #[wasm_bindgen(js_name = withVCFrag)]
-    pub fn with_vcfrag(&self, vcfrag: &VerifiedCapsuleFrag) -> MessageKitWithFrags {
-        MessageKitWithFrags {
-            message_kit: self.0.clone(),
-            vcfrags: vec![vcfrag.inner()],
-        }
-    }
-
-    pub fn decrypt(&self, sk: &SecretKey) -> Result<Box<[u8]>, JsValue> {
-        self.0.decrypt(sk.inner()).map_err(map_js_err)
+    pub fn decrypt(&self, sk: &SecretKey) -> Result<Box<[u8]>, Error> {
+        self.0.decrypt(sk.as_ref()).map_err(map_js_err)
     }
 
     #[wasm_bindgen(getter)]
     pub fn capsule(&self) -> Capsule {
-        Capsule::new(self.0.capsule)
+        Capsule::from(self.0.capsule)
     }
 
     #[wasm_bindgen(getter)]
@@ -163,7 +256,7 @@ impl MessageKit {
     }
 
     #[wasm_bindgen(js_name = fromBytes)]
-    pub fn from_bytes(data: &[u8]) -> Result<MessageKit, JsValue> {
+    pub fn from_bytes(data: &[u8]) -> Result<MessageKit, Error> {
         from_bytes::<_, nucypher_core::MessageKit>(data)
     }
 
@@ -171,34 +264,22 @@ impl MessageKit {
     pub fn to_bytes(&self) -> Box<[u8]> {
         to_bytes(self)
     }
-}
-
-#[wasm_bindgen]
-#[derive(Clone)]
-pub struct MessageKitWithFrags {
-    message_kit: nucypher_core::MessageKit,
-    vcfrags: Vec<umbral_pre::VerifiedCapsuleFrag>,
-}
-
-#[wasm_bindgen]
-impl MessageKitWithFrags {
-    #[wasm_bindgen(js_name = withVCFrag)]
-    pub fn with_vcfrag(&mut self, vcfrag: &VerifiedCapsuleFrag) -> Self {
-        self.vcfrags.push(vcfrag.inner());
-        self.clone()
-    }
 
     #[wasm_bindgen(js_name = decryptReencrypted)]
     pub fn decrypt_reencrypted(
         &self,
         sk: &SecretKey,
         policy_encrypting_key: &PublicKey,
-    ) -> Result<Box<[u8]>, JsValue> {
-        self.message_kit
+        vcfrags: &VerifiedCapsuleFragArray,
+    ) -> Result<Box<[u8]>, Error> {
+        let typed_vcfrags = try_from_js_array::<VerifiedCapsuleFrag>(vcfrags.as_ref())?;
+        self.0
             .decrypt_reencrypted(
-                sk.inner(),
-                policy_encrypting_key.inner(),
-                self.vcfrags.clone(),
+                sk.as_ref(),
+                policy_encrypting_key.as_ref(),
+                typed_vcfrags
+                    .into_iter()
+                    .map(umbral_pre::VerifiedCapsuleFrag::from),
             )
             .map_err(map_js_err)
     }
@@ -221,14 +302,14 @@ impl HRAC {
         label: &[u8],
     ) -> Self {
         Self(nucypher_core::HRAC::new(
-            publisher_verifying_key.inner(),
-            bob_verifying_key.inner(),
+            publisher_verifying_key.as_ref(),
+            bob_verifying_key.as_ref(),
             label,
         ))
     }
 
     #[wasm_bindgen(js_name = fromBytes)]
-    pub fn from_bytes(bytes: &[u8]) -> Result<HRAC, JsValue> {
+    pub fn from_bytes(bytes: &[u8]) -> Result<HRAC, Error> {
         let bytes: [u8; nucypher_core::HRAC::SIZE] = bytes.try_into().map_err(map_js_err)?;
         Ok(Self(bytes.into()))
     }
@@ -249,8 +330,9 @@ impl HRAC {
 // EncryptedKeyFrag
 //
 
+#[derive(TryFromJsValue)]
 #[wasm_bindgen]
-#[derive(Serialize, Deserialize, PartialEq, Debug, derive_more::From, derive_more::AsRef)]
+#[derive(Clone, PartialEq, Debug, derive_more::From, derive_more::AsRef)]
 pub struct EncryptedKeyFrag(nucypher_core::EncryptedKeyFrag);
 
 #[wasm_bindgen]
@@ -263,10 +345,10 @@ impl EncryptedKeyFrag {
         verified_kfrag: &VerifiedKeyFrag,
     ) -> Self {
         Self(nucypher_core::EncryptedKeyFrag::new(
-            signer.inner(),
-            recipient_key.inner(),
+            signer.as_ref(),
+            recipient_key.as_ref(),
             &hrac.0,
-            verified_kfrag.inner().clone(),
+            verified_kfrag.as_ref().clone(),
         ))
     }
 
@@ -275,15 +357,15 @@ impl EncryptedKeyFrag {
         sk: &SecretKey,
         hrac: &HRAC,
         publisher_verifying_key: &PublicKey,
-    ) -> Result<VerifiedKeyFrag, JsValue> {
+    ) -> Result<VerifiedKeyFrag, Error> {
         self.0
-            .decrypt(sk.inner(), &hrac.0, publisher_verifying_key.inner())
+            .decrypt(sk.as_ref(), &hrac.0, publisher_verifying_key.as_ref())
             .map_err(map_js_err)
-            .map(VerifiedKeyFrag::new)
+            .map(VerifiedKeyFrag::from)
     }
 
     #[wasm_bindgen(js_name = fromBytes)]
-    pub fn from_bytes(data: &[u8]) -> Result<EncryptedKeyFrag, JsValue> {
+    pub fn from_bytes(data: &[u8]) -> Result<EncryptedKeyFrag, Error> {
         from_bytes::<_, nucypher_core::EncryptedKeyFrag>(data)
     }
 
@@ -298,87 +380,90 @@ impl EncryptedKeyFrag {
 //
 
 #[wasm_bindgen]
-impl TreasureMapBuilder {
+#[derive(Clone, PartialEq, Debug, derive_more::From, derive_more::AsRef)]
+pub struct TreasureMap(nucypher_core::TreasureMap);
+
+#[wasm_bindgen]
+impl TreasureMap {
     #[wasm_bindgen(constructor)]
     pub fn new(
         signer: &Signer,
         hrac: &HRAC,
         policy_encrypting_key: &PublicKey,
+        assigned_kfrags: &AssignedKeyFragsArray,
         threshold: u8,
-    ) -> Result<TreasureMapBuilder, JsValue> {
-        Ok(Self {
-            signer: signer.inner().clone(),
-            hrac: hrac.0,
-            policy_encrypting_key: *policy_encrypting_key.inner(),
-            assigned_kfrags: Vec::new(),
+    ) -> Result<TreasureMap, Error> {
+        let js_kfrags: &JsValue = assigned_kfrags.as_ref();
+        let kfrags_array: &js_sys::Array = js_kfrags
+            .dyn_ref()
+            .ok_or_else(|| Error::new("`assigned_kfrags` must be an array"))?;
+
+        let mut typed_assigned_kfrags = Vec::new();
+
+        for entry in kfrags_array.iter() {
+            let key_value: js_sys::Array = entry.dyn_into()?;
+            if key_value.length() != 2 {
+                return Err(Error::new(
+                    "A tuple of an incorrect size received when iterating through map's entries",
+                ));
+            }
+            let key = key_value.get(0);
+            let value = key_value.get(1);
+
+            let value_tuple: js_sys::Array = value.dyn_into()?;
+            if value_tuple.length() != 2 {
+                return Err(Error::new(
+                    "A tuple of an incorrect size received when iterating through map's entries",
+                ));
+            }
+
+            let address = Address::try_from(&key).map_err(map_js_err)?;
+            let pk = PublicKey::try_from(&value_tuple.get(0)).map_err(map_js_err)?;
+            let kfrag = VerifiedKeyFrag::try_from(&value_tuple.get(1)).map_err(map_js_err)?;
+
+            typed_assigned_kfrags.push((address.0, (pk.into(), kfrag.into())));
+        }
+
+        Ok(Self(nucypher_core::TreasureMap::new(
+            signer.as_ref(),
+            &hrac.0,
+            policy_encrypting_key.as_ref(),
+            typed_assigned_kfrags,
             threshold,
-        })
+        )))
     }
 
-    #[wasm_bindgen(js_name = addKfrag)]
-    pub fn add_kfrag(
-        &mut self,
-        address: &[u8],
-        public_key: &PublicKey,
-        vkfrag: &VerifiedKeyFrag,
-    ) -> Result<TreasureMapBuilder, JsValue> {
-        let address = try_make_address(address)?;
-        self.assigned_kfrags
-            .push((address, (*public_key.inner(), vkfrag.inner().clone())));
-        Ok(self.clone())
-    }
-
-    #[wasm_bindgen]
-    pub fn build(&self) -> TreasureMap {
-        TreasureMap(nucypher_core::TreasureMap::new(
-            &self.signer,
-            &self.hrac,
-            &self.policy_encrypting_key,
-            self.assigned_kfrags.clone(),
-            self.threshold,
-        ))
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Clone, PartialEq, Debug, derive_more::From, derive_more::AsRef)]
-pub struct TreasureMap(nucypher_core::TreasureMap);
-
-#[wasm_bindgen]
-#[derive(Clone)]
-pub struct TreasureMapBuilder {
-    signer: umbral_pre::Signer,
-    hrac: nucypher_core::HRAC,
-    policy_encrypting_key: umbral_pre::PublicKey,
-    assigned_kfrags: Vec<(
-        nucypher_core::Address,
-        (umbral_pre::PublicKey, umbral_pre::VerifiedKeyFrag),
-    )>,
-    threshold: u8,
-}
-
-#[wasm_bindgen]
-impl TreasureMap {
     pub fn encrypt(&self, signer: &Signer, recipient_key: &PublicKey) -> EncryptedTreasureMap {
-        EncryptedTreasureMap(self.0.encrypt(signer.inner(), recipient_key.inner()))
+        EncryptedTreasureMap(self.0.encrypt(signer.as_ref(), recipient_key.as_ref()))
     }
 
     #[wasm_bindgen(getter)]
-    pub fn destinations(&self) -> Result<JsValue, JsValue> {
-        let mut result = Vec::new();
-        for (address, ekfrag) in &self.0.destinations {
-            result.push((address, EncryptedKeyFrag(ekfrag.clone())));
-        }
-        Ok(serde_wasm_bindgen::to_value(&result)?)
+    pub fn destinations(&self) -> DestinationsArray {
+        self.0
+            .destinations
+            .iter()
+            .map(|(address, ekfrag)| {
+                [
+                    JsValue::from(Address(address.clone())),
+                    JsValue::from(EncryptedKeyFrag(ekfrag.clone())),
+                ]
+                .iter()
+                .collect::<js_sys::Array>()
+            })
+            .map(JsValue::from)
+            .collect::<js_sys::Array>()
+            .unchecked_into::<DestinationsArray>()
     }
 
     #[wasm_bindgen(js_name = makeRevocationOrders)]
-    pub fn make_revocation_orders(&self, signer: &Signer) -> Vec<JsValue> {
+    pub fn make_revocation_orders(&self, signer: &Signer) -> RevocationOrderArray {
         self.0
-            .make_revocation_orders(signer.inner())
-            .iter()
-            .map(|order| serde_wasm_bindgen::to_value(&order).unwrap())
-            .collect()
+            .make_revocation_orders(signer.as_ref())
+            .into_iter()
+            .map(RevocationOrder)
+            .map(JsValue::from)
+            .collect::<js_sys::Array>()
+            .unchecked_into::<RevocationOrderArray>()
     }
 
     #[wasm_bindgen(getter)]
@@ -393,16 +478,16 @@ impl TreasureMap {
 
     #[wasm_bindgen(getter, js_name = policyEncryptingKey)]
     pub fn policy_encrypting_key(&self) -> PublicKey {
-        PublicKey::new(self.0.policy_encrypting_key)
+        PublicKey::from(self.0.policy_encrypting_key)
     }
 
     #[wasm_bindgen(getter, js_name = publisherVerifyingKey)]
     pub fn publisher_verifying_key(&self) -> PublicKey {
-        PublicKey::new(self.0.publisher_verifying_key)
+        PublicKey::from(self.0.publisher_verifying_key)
     }
 
     #[wasm_bindgen(js_name = fromBytes)]
-    pub fn from_bytes(data: &[u8]) -> Result<TreasureMap, JsValue> {
+    pub fn from_bytes(data: &[u8]) -> Result<TreasureMap, Error> {
         from_bytes::<_, nucypher_core::TreasureMap>(data)
     }
 
@@ -426,15 +511,15 @@ impl EncryptedTreasureMap {
         &self,
         sk: &SecretKey,
         publisher_verifying_key: &PublicKey,
-    ) -> Result<TreasureMap, JsValue> {
+    ) -> Result<TreasureMap, Error> {
         self.0
-            .decrypt(sk.inner(), publisher_verifying_key.inner())
+            .decrypt(sk.as_ref(), publisher_verifying_key.as_ref())
             .map_err(map_js_err)
             .map(TreasureMap)
     }
 
     #[wasm_bindgen(js_name = fromBytes)]
-    pub fn from_bytes(data: &[u8]) -> Result<EncryptedTreasureMap, JsValue> {
+    pub fn from_bytes(data: &[u8]) -> Result<EncryptedTreasureMap, Error> {
         from_bytes::<_, nucypher_core::EncryptedTreasureMap>(data)
     }
 
@@ -453,61 +538,35 @@ impl EncryptedTreasureMap {
 pub struct ReencryptionRequest(nucypher_core::ReencryptionRequest);
 
 #[wasm_bindgen]
-#[derive(Clone)]
-pub struct ReencryptionRequestBuilder {
-    capsules: Vec<umbral_pre::Capsule>,
-    hrac: nucypher_core::HRAC,
-    encrypted_kfrag: nucypher_core::EncryptedKeyFrag,
-    publisher_verifying_key: umbral_pre::PublicKey,
-    bob_verifying_key: umbral_pre::PublicKey,
-    conditions: Option<nucypher_core::Conditions>,
-    context: Option<nucypher_core::Context>,
-}
-
-#[wasm_bindgen]
-impl ReencryptionRequestBuilder {
+impl ReencryptionRequest {
     #[wasm_bindgen(constructor)]
     pub fn new(
+        capsules: &CapsuleArray,
         hrac: &HRAC,
         encrypted_kfrag: &EncryptedKeyFrag,
         publisher_verifying_key: &PublicKey,
         bob_verifying_key: &PublicKey,
-        conditions: Option<Conditions>,
-        context: Option<Context>,
-    ) -> Result<ReencryptionRequestBuilder, JsValue> {
-        Ok(Self {
-            capsules: Vec::new(),
-            hrac: hrac.0,
-            encrypted_kfrag: encrypted_kfrag.0.clone(),
-            publisher_verifying_key: *publisher_verifying_key.inner(),
-            bob_verifying_key: *bob_verifying_key.inner(),
-            conditions: conditions.map(|conditions| conditions.0),
-            context: context.map(|context| context.0),
-        })
+        conditions: &OptionConditions,
+        context: &OptionContext,
+    ) -> Result<ReencryptionRequest, Error> {
+        let typed_conditions = try_from_js_option::<Conditions>(conditions.as_ref())?;
+        let typed_context = try_from_js_option::<Context>(context.as_ref())?;
+        let typed_capsules = try_from_js_array::<Capsule>(capsules.as_ref())?;
+        let backend_capules = typed_capsules
+            .into_iter()
+            .map(umbral_pre::Capsule::from)
+            .collect::<Vec<_>>();
+        Ok(Self(nucypher_core::ReencryptionRequest::new(
+            &backend_capules,
+            &hrac.0,
+            &encrypted_kfrag.0,
+            publisher_verifying_key.as_ref(),
+            bob_verifying_key.as_ref(),
+            typed_conditions.as_ref().map(|conditions| &conditions.0),
+            typed_context.as_ref().map(|context| &context.0),
+        )))
     }
 
-    #[wasm_bindgen(js_name = addCapsule)]
-    pub fn add_capsule(&mut self, capsule: &Capsule) -> Self {
-        self.capsules.push(*capsule.inner());
-        self.clone()
-    }
-
-    #[wasm_bindgen]
-    pub fn build(&self) -> ReencryptionRequest {
-        ReencryptionRequest(nucypher_core::ReencryptionRequest::new(
-            &self.capsules,
-            &self.hrac,
-            &self.encrypted_kfrag,
-            &self.publisher_verifying_key,
-            &self.bob_verifying_key,
-            self.conditions.as_ref(),
-            self.context.as_ref(),
-        ))
-    }
-}
-
-#[wasm_bindgen]
-impl ReencryptionRequest {
     #[wasm_bindgen(getter)]
     pub fn hrac(&self) -> HRAC {
         HRAC(self.0.hrac)
@@ -515,12 +574,12 @@ impl ReencryptionRequest {
 
     #[wasm_bindgen(getter, js_name = publisherVerifyingKey)]
     pub fn publisher_verifying_key(&self) -> PublicKey {
-        PublicKey::new(self.0.publisher_verifying_key)
+        PublicKey::from(self.0.publisher_verifying_key)
     }
 
     #[wasm_bindgen(getter, js_name = bobVerifyingKey)]
     pub fn bob_verifying_key(&self) -> PublicKey {
-        PublicKey::new(self.0.bob_verifying_key)
+        PublicKey::from(self.0.bob_verifying_key)
     }
 
     #[wasm_bindgen(getter, js_name = encryptedKfrag)]
@@ -529,17 +588,19 @@ impl ReencryptionRequest {
     }
 
     #[wasm_bindgen(getter)]
-    pub fn capsules(&self) -> Vec<JsValue> {
+    pub fn capsules(&self) -> CapsuleArray {
         self.0
             .capsules
             .iter()
-            .map(|capsule| Capsule::new(*capsule))
+            .cloned()
+            .map(Capsule::from)
             .map(JsValue::from)
-            .collect()
+            .collect::<js_sys::Array>()
+            .unchecked_into::<CapsuleArray>()
     }
 
     #[wasm_bindgen(js_name = fromBytes)]
-    pub fn from_bytes(data: &[u8]) -> Result<ReencryptionRequest, JsValue> {
+    pub fn from_bytes(data: &[u8]) -> Result<ReencryptionRequest, Error> {
         from_bytes::<_, nucypher_core::ReencryptionRequest>(data)
     }
 
@@ -564,62 +625,38 @@ impl ReencryptionRequest {
 //
 
 #[wasm_bindgen]
-#[derive(Clone)]
-pub struct ReencryptionResponseBuilder {
-    signer: umbral_pre::Signer,
-    capsules: Vec<umbral_pre::Capsule>,
-    vcfrags: Vec<umbral_pre::VerifiedCapsuleFrag>,
-}
-
-#[wasm_bindgen]
-impl ReencryptionResponseBuilder {
-    #[wasm_bindgen(constructor)]
-    pub fn new(signer: &Signer) -> Self {
-        Self {
-            signer: signer.inner().clone(),
-            capsules: Vec::new(),
-            vcfrags: Vec::new(),
-        }
-    }
-
-    #[wasm_bindgen(js_name = addCapsule)]
-    pub fn add_capsule(&mut self, capsule: &Capsule) -> ReencryptionResponseBuilder {
-        self.capsules.push(*capsule.inner());
-        self.clone()
-    }
-
-    #[wasm_bindgen(js_name = addCfrag)]
-    pub fn add_cfrag(&mut self, cfrag: &VerifiedCapsuleFrag) -> ReencryptionResponseBuilder {
-        self.vcfrags.push(cfrag.inner());
-        self.clone()
-    }
-
-    #[wasm_bindgen]
-    pub fn build(&self) -> ReencryptionResponse {
-        ReencryptionResponse(nucypher_core::ReencryptionResponse::new(
-            &self.signer,
-            &self.capsules,
-            self.vcfrags.clone(),
-        ))
-    }
-}
-
-#[wasm_bindgen]
 #[derive(derive_more::From, derive_more::AsRef)]
 pub struct ReencryptionResponse(nucypher_core::ReencryptionResponse);
 
 #[wasm_bindgen]
 impl ReencryptionResponse {
-    #[wasm_bindgen(js_name = withCapsule)]
-    pub fn with_capsule(&self, capsule: &Capsule) -> ReencryptionResponseWithCapsules {
-        ReencryptionResponseWithCapsules {
-            reencryption_response: self.0.clone(),
-            capsules: vec![*capsule.inner()],
-        }
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        signer: &Signer,
+        capsules: &CapsuleArray,
+        vcfrags: &VerifiedCapsuleFragArray,
+    ) -> Result<ReencryptionResponse, Error> {
+        let typed_capsules = try_from_js_array::<Capsule>(capsules.as_ref())?;
+        let typed_vcfrags = try_from_js_array::<VerifiedCapsuleFrag>(vcfrags.as_ref())?;
+
+        let backend_capsules = typed_capsules
+            .into_iter()
+            .map(umbral_pre::Capsule::from)
+            .collect::<Vec<_>>();
+        let backend_vcfrags = typed_vcfrags
+            .into_iter()
+            .map(umbral_pre::VerifiedCapsuleFrag::from)
+            .collect::<Vec<_>>();
+
+        Ok(Self(nucypher_core::ReencryptionResponse::new(
+            signer.as_ref(),
+            &backend_capsules,
+            backend_vcfrags,
+        )))
     }
 
     #[wasm_bindgen(js_name = fromBytes)]
-    pub fn from_bytes(data: &[u8]) -> Result<ReencryptionResponse, JsValue> {
+    pub fn from_bytes(data: &[u8]) -> Result<ReencryptionResponse, Error> {
         from_bytes::<_, nucypher_core::ReencryptionResponse>(data)
     }
 
@@ -627,61 +664,41 @@ impl ReencryptionResponse {
     pub fn to_bytes(&self) -> Box<[u8]> {
         to_bytes(self)
     }
-}
-
-impl ReencryptionResponse {
-    pub fn inner(&self) -> &nucypher_core::ReencryptionResponse {
-        &self.0
-    }
-}
-
-#[wasm_bindgen]
-pub struct ReencryptionResponseWithCapsules {
-    reencryption_response: nucypher_core::ReencryptionResponse,
-    capsules: Vec<umbral_pre::Capsule>,
-}
-
-#[wasm_bindgen]
-impl ReencryptionResponseWithCapsules {
-    #[wasm_bindgen(js_name = withCapsule)]
-    pub fn with_capsule(&self, capsule: &Capsule) -> ReencryptionResponseWithCapsules {
-        let mut capsules = self.capsules.clone();
-        capsules.push(*capsule.inner());
-        ReencryptionResponseWithCapsules {
-            reencryption_response: self.reencryption_response.clone(),
-            capsules,
-        }
-    }
 
     #[wasm_bindgen]
     pub fn verify(
         &self,
+        capsules: &CapsuleArray,
         alice_verifying_key: &PublicKey,
         ursula_verifying_key: &PublicKey,
         policy_encrypting_key: &PublicKey,
         bob_encrypting_key: &PublicKey,
-    ) -> Result<Box<[JsValue]>, JsValue> {
-        let vcfrags_backend = self
-            .reencryption_response
+    ) -> Result<VerifiedCapsuleFragArray, Error> {
+        let typed_capsules = try_from_js_array::<Capsule>(capsules.as_ref())?;
+        let backend_capsules = typed_capsules
+            .into_iter()
+            .map(|capsule| *capsule.as_ref())
+            .collect::<Vec<_>>();
+        let backend_vcfrags = self
+            .0
             .verify(
-                &self.capsules,
-                alice_verifying_key.inner(),
-                ursula_verifying_key.inner(),
-                policy_encrypting_key.inner(),
-                bob_encrypting_key.inner(),
+                &backend_capsules,
+                alice_verifying_key.as_ref(),
+                ursula_verifying_key.as_ref(),
+                policy_encrypting_key.as_ref(),
+                bob_encrypting_key.as_ref(),
             )
             .map_err(|_err| {
                 JsValue::from(Error::new("ReencryptionResponse verification failed"))
             })?;
 
-        let vcfrags_backend_js = vcfrags_backend
-            .iter()
-            .map(|vcfrag| VerifiedCapsuleFrag::new(vcfrag.clone()))
-            .map(|vcfrag| serde_wasm_bindgen::to_value(&vcfrag))
+        Ok(backend_vcfrags
+            .into_vec()
             .into_iter()
-            .collect::<Result<Box<_>, _>>()
-            .map_err(map_js_err)?;
-        Ok(vcfrags_backend_js)
+            .map(VerifiedCapsuleFrag::from)
+            .map(JsValue::from)
+            .collect::<js_sys::Array>()
+            .unchecked_into::<VerifiedCapsuleFragArray>())
     }
 }
 
@@ -690,47 +707,30 @@ impl ReencryptionResponseWithCapsules {
 //
 
 #[wasm_bindgen]
-#[derive(Clone)]
-pub struct RetrievalKitBuilder {
-    capsule: umbral_pre::Capsule,
-    queried_addresses: Vec<nucypher_core::Address>,
-    conditions: Option<Conditions>,
-}
-
-#[wasm_bindgen]
-impl RetrievalKitBuilder {
-    #[wasm_bindgen(constructor)]
-    pub fn new(capsule: &Capsule, conditions: Option<Conditions>) -> Self {
-        Self {
-            capsule: *capsule.inner(),
-            queried_addresses: Vec::new(),
-            conditions,
-        }
-    }
-
-    #[wasm_bindgen(js_name = addQueriedAddress)]
-    pub fn add_queried_address(&mut self, address: &[u8]) -> Result<RetrievalKitBuilder, JsValue> {
-        let address = try_make_address(address)?;
-        self.queried_addresses.push(address);
-        Ok(self.clone())
-    }
-
-    #[wasm_bindgen]
-    pub fn build(&self) -> RetrievalKit {
-        RetrievalKit(nucypher_core::RetrievalKit::new(
-            &self.capsule,
-            self.queried_addresses.clone(),
-            self.conditions.as_ref().map(|conditions| &conditions.0),
-        ))
-    }
-}
-
-#[wasm_bindgen]
 #[derive(derive_more::From, derive_more::AsRef)]
 pub struct RetrievalKit(nucypher_core::RetrievalKit);
 
 #[wasm_bindgen]
 impl RetrievalKit {
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        capsule: &Capsule,
+        queried_addresses: &AddressArray,
+        conditions: &OptionConditions,
+    ) -> Result<RetrievalKit, Error> {
+        let typed_conditions = try_from_js_option::<Conditions>(conditions.as_ref())?;
+        let typed_addresses = try_from_js_array::<Address>(queried_addresses.as_ref())?;
+        let backend_addresses = typed_addresses
+            .into_iter()
+            .map(|address| address.0)
+            .collect::<Vec<_>>();
+        Ok(Self(nucypher_core::RetrievalKit::new(
+            capsule.as_ref(),
+            backend_addresses,
+            typed_conditions.as_ref().map(|conditions| &conditions.0),
+        )))
+    }
+
     #[wasm_bindgen(js_name = fromMessageKit)]
     pub fn from_message_kit(message_kit: &MessageKit) -> Self {
         RetrievalKit(nucypher_core::RetrievalKit::from_message_kit(
@@ -740,22 +740,23 @@ impl RetrievalKit {
 
     #[wasm_bindgen(getter)]
     pub fn capsule(&self) -> Capsule {
-        Capsule::new(self.0.capsule)
+        Capsule::from(self.0.capsule)
     }
 
     #[wasm_bindgen(getter, js_name = queriedAddresses)]
-    pub fn queried_addresses(&self) -> Result<Vec<JsValue>, JsValue> {
+    pub fn queried_addresses(&self) -> AddressArray {
         self.0
             .queried_addresses
             .iter()
-            .map(|address| serde_wasm_bindgen::to_value(&address))
-            .into_iter()
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(map_js_err)
+            .cloned()
+            .map(Address::from)
+            .map(JsValue::from)
+            .collect::<js_sys::Array>()
+            .unchecked_into::<AddressArray>()
     }
 
     #[wasm_bindgen(js_name = fromBytes)]
-    pub fn from_bytes(data: &[u8]) -> Result<RetrievalKit, JsValue> {
+    pub fn from_bytes(data: &[u8]) -> Result<RetrievalKit, Error> {
         from_bytes::<_, nucypher_core::RetrievalKit>(data)
     }
 
@@ -775,7 +776,7 @@ impl RetrievalKit {
 //
 
 #[wasm_bindgen]
-#[derive(Serialize, Deserialize, PartialEq, Debug, derive_more::From, derive_more::AsRef)]
+#[derive(PartialEq, Debug, derive_more::From, derive_more::AsRef)]
 pub struct RevocationOrder(nucypher_core::RevocationOrder);
 
 #[wasm_bindgen]
@@ -783,13 +784,12 @@ impl RevocationOrder {
     #[wasm_bindgen(constructor)]
     pub fn new(
         signer: &Signer,
-        staking_provider_address: &[u8],
+        staking_provider_address: &Address,
         encrypted_kfrag: &EncryptedKeyFrag,
-    ) -> Result<RevocationOrder, JsValue> {
-        let address = try_make_address(staking_provider_address)?;
+    ) -> Result<RevocationOrder, Error> {
         Ok(Self(nucypher_core::RevocationOrder::new(
-            signer.inner(),
-            &address,
+            signer.as_ref(),
+            &staking_provider_address.0,
             &encrypted_kfrag.0,
         )))
     }
@@ -798,19 +798,19 @@ impl RevocationOrder {
     pub fn verify(
         &self,
         alice_verifying_key: &PublicKey,
-    ) -> Result<VerifiedRevocationOrder, JsValue> {
+    ) -> Result<VerifiedRevocationOrder, Error> {
         self.0
             .clone()
-            .verify(alice_verifying_key.inner())
-            .map(|(address, ekfrag)| VerifiedRevocationOrder {
-                address: address.as_ref().to_vec().into_boxed_slice(),
-                encrypted_kfrag: ekfrag,
+            .verify(alice_verifying_key.as_ref())
+            .map(|(address, encrypted_kfrag)| VerifiedRevocationOrder {
+                address,
+                encrypted_kfrag,
             })
-            .map_err(|_err| Error::new("Failed to verify RevocationOrder").into())
+            .map_err(|_err| Error::new("Failed to verify RevocationOrder"))
     }
 
     #[wasm_bindgen(js_name = fromBytes)]
-    pub fn from_bytes(data: &[u8]) -> Result<RevocationOrder, JsValue> {
+    pub fn from_bytes(data: &[u8]) -> Result<RevocationOrder, Error> {
         from_bytes::<_, nucypher_core::RevocationOrder>(data)
     }
 
@@ -823,15 +823,15 @@ impl RevocationOrder {
 // wasm-bindgen does not support returning tuples, so have to use a struct.
 #[wasm_bindgen]
 pub struct VerifiedRevocationOrder {
-    address: Box<[u8]>,
+    address: nucypher_core::Address,
     encrypted_kfrag: nucypher_core::EncryptedKeyFrag,
 }
 
 #[wasm_bindgen]
 impl VerifiedRevocationOrder {
     #[wasm_bindgen(getter)]
-    pub fn address(&self) -> Box<[u8]> {
-        self.address.clone()
+    pub fn address(&self) -> Address {
+        Address(self.address)
     }
 
     #[wasm_bindgen(getter, js_name = encryptedKFrag)]
@@ -852,7 +852,7 @@ impl NodeMetadataPayload {
     #[allow(clippy::too_many_arguments)]
     #[wasm_bindgen(constructor)]
     pub fn new(
-        staking_provider_address: &[u8],
+        staking_provider_address: &Address,
         domain: &str,
         timestamp_epoch: u32,
         verifying_key: &PublicKey,
@@ -860,27 +860,30 @@ impl NodeMetadataPayload {
         certificate_der: &[u8],
         host: &str,
         port: u16,
-        operator_signature: Option<Vec<u8>>,
-    ) -> Result<NodeMetadataPayload, JsValue> {
-        let address = try_make_address(staking_provider_address)?;
+        operator_signature: OptionUint8Array,
+    ) -> Result<NodeMetadataPayload, Error> {
+        let js_sig: JsValue = operator_signature.into();
+        let typed_signature = if js_sig.is_null() {
+            None
+        } else {
+            let sig: Uint8Array = js_sig.dyn_into()?;
+            Some(sig)
+        };
 
-        let signature = operator_signature
+        let signature = typed_signature
             .map(|signature_bytes| {
-                recoverable::Signature::from_bytes(&signature_bytes).map_err(|err| {
-                    JsValue::from(Error::new(&format!(
-                        "Incorrect operator signature format: {}",
-                        err
-                    )))
+                recoverable::Signature::from_bytes(&signature_bytes.to_vec()).map_err(|err| {
+                    Error::new(&format!("Incorrect operator signature format: {}", err))
                 })
             })
             .transpose()?;
 
         Ok(Self(nucypher_core::NodeMetadataPayload {
-            staking_provider_address: address,
+            staking_provider_address: staking_provider_address.0,
             domain: domain.to_string(),
             timestamp_epoch,
-            verifying_key: *verifying_key.inner(),
-            encrypting_key: *encrypting_key.inner(),
+            verifying_key: *verifying_key.as_ref(),
+            encrypting_key: *encrypting_key.as_ref(),
             certificate_der: certificate_der.into(),
             host: host.to_string(),
             port,
@@ -889,18 +892,18 @@ impl NodeMetadataPayload {
     }
 
     #[wasm_bindgen(getter)]
-    pub fn staking_provider_address(&self) -> Vec<u8> {
-        self.0.staking_provider_address.as_ref().to_vec()
+    pub fn staking_provider_address(&self) -> Address {
+        Address(self.0.staking_provider_address)
     }
 
     #[wasm_bindgen(getter, js_name = verifyingKey)]
     pub fn verifying_key(&self) -> PublicKey {
-        PublicKey::new(self.0.verifying_key)
+        PublicKey::from(self.0.verifying_key)
     }
 
     #[wasm_bindgen(getter, js_name = encryptingKey)]
     pub fn encrypting_key(&self) -> PublicKey {
-        PublicKey::new(self.0.encrypting_key)
+        PublicKey::from(self.0.encrypting_key)
     }
 
     #[wasm_bindgen(getter)]
@@ -936,10 +939,10 @@ impl NodeMetadataPayload {
     }
 
     #[wasm_bindgen(js_name = deriveOperatorAddress)]
-    pub fn derive_operator_address(&self) -> Result<Vec<u8>, JsValue> {
+    pub fn derive_operator_address(&self) -> Result<Address, Error> {
         self.0
             .derive_operator_address()
-            .map(|address| address.as_ref().to_vec())
+            .map(Address)
             .map_err(map_js_err)
     }
 }
@@ -948,17 +951,19 @@ impl NodeMetadataPayload {
 // NodeMetadata
 //
 
+#[derive(TryFromJsValue)]
 #[wasm_bindgen]
-#[derive(
-    Clone, Serialize, Deserialize, PartialEq, Debug, derive_more::From, derive_more::AsRef,
-)]
+#[derive(Clone, PartialEq, Eq, Debug, derive_more::From, derive_more::AsRef)]
 pub struct NodeMetadata(nucypher_core::NodeMetadata);
 
 #[wasm_bindgen]
 impl NodeMetadata {
     #[wasm_bindgen(constructor)]
     pub fn new(signer: &Signer, payload: &NodeMetadataPayload) -> Self {
-        Self(nucypher_core::NodeMetadata::new(signer.inner(), &payload.0))
+        Self(nucypher_core::NodeMetadata::new(
+            signer.as_ref(),
+            &payload.0,
+        ))
     }
 
     pub fn verify(&self) -> bool {
@@ -971,7 +976,7 @@ impl NodeMetadata {
     }
 
     #[wasm_bindgen(js_name = fromBytes)]
-    pub fn from_bytes(data: &[u8]) -> Result<NodeMetadata, JsValue> {
+    pub fn from_bytes(data: &[u8]) -> Result<NodeMetadata, Error> {
         from_bytes::<_, nucypher_core::NodeMetadata>(data)
     }
 
@@ -981,51 +986,9 @@ impl NodeMetadata {
     }
 }
 
-// TODO: Replace inner() with From<>?
-impl NodeMetadata {
-    pub fn inner(&self) -> &nucypher_core::NodeMetadata {
-        &self.0
-    }
-}
-
 //
 // FleetStateChecksum
 //
-
-#[wasm_bindgen]
-#[derive(Clone)]
-pub struct FleetStateChecksumBuilder {
-    this_node: Option<nucypher_core::NodeMetadata>,
-    other_nodes: Vec<nucypher_core::NodeMetadata>,
-}
-
-#[wasm_bindgen]
-impl FleetStateChecksumBuilder {
-    // TODO: Fix lack of reference leading to accidental freeing of memory
-    //       https://github.com/rustwasm/wasm-bindgen/issues/2370
-    // this_node: Option<&NodeMetadata>,
-    #[wasm_bindgen(constructor)]
-    pub fn new(this_node: Option<NodeMetadata>) -> Self {
-        Self {
-            this_node: this_node.map(|n| n.0),
-            other_nodes: Vec::new(),
-        }
-    }
-
-    #[wasm_bindgen(js_name = addOtherNode)]
-    pub fn add_other_node(&mut self, other_node: &NodeMetadata) -> Self {
-        self.other_nodes.push(other_node.inner().clone());
-        self.clone()
-    }
-
-    #[wasm_bindgen]
-    pub fn build(&self) -> FleetStateChecksum {
-        FleetStateChecksum(nucypher_core::FleetStateChecksum::from_nodes(
-            self.this_node.as_ref(),
-            &self.other_nodes,
-        ))
-    }
-}
 
 #[wasm_bindgen]
 #[derive(Clone, derive_more::AsRef)]
@@ -1033,6 +996,23 @@ pub struct FleetStateChecksum(nucypher_core::FleetStateChecksum);
 
 #[wasm_bindgen]
 impl FleetStateChecksum {
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        this_node: &OptionNodeMetadata,
+        other_nodes: &NodeMetadataArray,
+    ) -> Result<FleetStateChecksum, Error> {
+        let typed_this_node = try_from_js_option::<NodeMetadata>(this_node.as_ref())?;
+        let typed_nodes = try_from_js_array::<NodeMetadata>(other_nodes.as_ref())?;
+        let backend_nodes = typed_nodes
+            .into_iter()
+            .map(|node| node.0)
+            .collect::<Vec<_>>();
+        Ok(Self(nucypher_core::FleetStateChecksum::from_nodes(
+            typed_this_node.as_ref().map(|node| &node.0),
+            &backend_nodes,
+        )))
+    }
+
     #[wasm_bindgen(js_name = toBytes)]
     pub fn to_bytes(&self) -> Box<[u8]> {
         self.0.as_ref().to_vec().into_boxed_slice()
@@ -1045,53 +1025,9 @@ impl FleetStateChecksum {
     }
 }
 
-impl FleetStateChecksum {
-    pub fn new(this_node: Option<NodeMetadata>, other_nodes: Vec<NodeMetadata>) -> Self {
-        let this_node = this_node.map(|n| n.0);
-        let other_nodes: Vec<nucypher_core::NodeMetadata> =
-            other_nodes.iter().cloned().map(|n| n.0).collect();
-        FleetStateChecksum(nucypher_core::FleetStateChecksum::from_nodes(
-            this_node.as_ref(),
-            &other_nodes,
-        ))
-    }
-}
-
 //
 // MetadataRequest
 //
-
-#[wasm_bindgen]
-#[derive(Clone)]
-pub struct MetadataRequestBuilder {
-    fleet_state_checksum: nucypher_core::FleetStateChecksum,
-    announce_nodes: Vec<nucypher_core::NodeMetadata>,
-}
-
-#[wasm_bindgen]
-impl MetadataRequestBuilder {
-    #[wasm_bindgen(constructor)]
-    pub fn new(fleet_state_checksum: &FleetStateChecksum) -> Self {
-        Self {
-            fleet_state_checksum: fleet_state_checksum.0,
-            announce_nodes: Vec::new(),
-        }
-    }
-
-    #[wasm_bindgen(js_name = addAnnounceNode)]
-    pub fn add_announce_node(&mut self, announce_node: &NodeMetadata) -> Self {
-        self.announce_nodes.push(announce_node.inner().clone());
-        self.clone()
-    }
-
-    #[wasm_bindgen]
-    pub fn build(&self) -> MetadataRequest {
-        MetadataRequest(nucypher_core::MetadataRequest::new(
-            &self.fleet_state_checksum,
-            &self.announce_nodes,
-        ))
-    }
-}
 
 #[wasm_bindgen]
 #[derive(derive_more::From, derive_more::AsRef)]
@@ -1099,23 +1035,40 @@ pub struct MetadataRequest(nucypher_core::MetadataRequest);
 
 #[wasm_bindgen]
 impl MetadataRequest {
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        fleet_state_checksum: &FleetStateChecksum,
+        announce_nodes: &NodeMetadataArray,
+    ) -> Result<MetadataRequest, Error> {
+        let typed_nodes = try_from_js_array::<NodeMetadata>(announce_nodes.as_ref())?;
+        let backend_nodes = typed_nodes
+            .into_iter()
+            .map(|node| node.0)
+            .collect::<Vec<_>>();
+        Ok(Self(nucypher_core::MetadataRequest::new(
+            &fleet_state_checksum.0,
+            &backend_nodes,
+        )))
+    }
+
     #[wasm_bindgen(getter, js_name = fleetStateChecksum)]
     pub fn fleet_state_checksum(&self) -> FleetStateChecksum {
         FleetStateChecksum(self.0.fleet_state_checksum)
     }
 
     #[wasm_bindgen(getter, js_name = announceNodes)]
-    pub fn announce_nodes(&self) -> Vec<JsValue> {
+    pub fn announce_nodes(&self) -> NodeMetadataArray {
         self.0
             .announce_nodes
             .iter()
             .map(|node| NodeMetadata(node.clone()))
             .map(JsValue::from)
-            .collect()
+            .collect::<js_sys::Array>()
+            .unchecked_into::<NodeMetadataArray>()
     }
 
     #[wasm_bindgen(js_name = fromBytes)]
-    pub fn from_bytes(data: &[u8]) -> Result<MetadataRequest, JsValue> {
+    pub fn from_bytes(data: &[u8]) -> Result<MetadataRequest, Error> {
         from_bytes::<_, nucypher_core::MetadataRequest>(data)
     }
 
@@ -1130,55 +1083,40 @@ impl MetadataRequest {
 //
 
 #[wasm_bindgen]
-#[derive(Clone)]
-pub struct MetadataResponsePayloadBuilder {
-    timestamp_epoch: u32,
-    announce_nodes: Vec<nucypher_core::NodeMetadata>,
-}
-
-#[wasm_bindgen]
-impl MetadataResponsePayloadBuilder {
-    #[wasm_bindgen(constructor)]
-    pub fn new(timestamp_epoch: u32) -> Self {
-        Self {
-            timestamp_epoch,
-            announce_nodes: Vec::new(),
-        }
-    }
-
-    #[wasm_bindgen(js_name = addAnnounceNode)]
-    pub fn add_announce_node(&mut self, announce_node: &NodeMetadata) -> Self {
-        self.announce_nodes.push(announce_node.inner().clone());
-        self.clone()
-    }
-
-    #[wasm_bindgen]
-    pub fn build(&self) -> MetadataResponsePayload {
-        MetadataResponsePayload(nucypher_core::MetadataResponsePayload::new(
-            self.timestamp_epoch,
-            &self.announce_nodes,
-        ))
-    }
-}
-
-#[wasm_bindgen]
 pub struct MetadataResponsePayload(nucypher_core::MetadataResponsePayload);
 
 #[wasm_bindgen]
 impl MetadataResponsePayload {
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        timestamp_epoch: u32,
+        announce_nodes: &NodeMetadataArray,
+    ) -> Result<MetadataResponsePayload, Error> {
+        let typed_nodes = try_from_js_array::<NodeMetadata>(announce_nodes.as_ref())?;
+        let backend_nodes = typed_nodes
+            .into_iter()
+            .map(|node| node.0)
+            .collect::<Vec<_>>();
+        Ok(Self(nucypher_core::MetadataResponsePayload::new(
+            timestamp_epoch,
+            &backend_nodes,
+        )))
+    }
+
     #[wasm_bindgen(getter)]
     pub fn timestamp_epoch(&self) -> u32 {
         self.0.timestamp_epoch
     }
 
     #[wasm_bindgen(getter, js_name = announceNodes)]
-    pub fn announce_nodes(&self) -> Vec<JsValue> {
+    pub fn announce_nodes(&self) -> NodeMetadataArray {
         self.0
             .announce_nodes
             .iter()
             .map(|node| NodeMetadata(node.clone()))
             .map(JsValue::from)
-            .collect()
+            .collect::<js_sys::Array>()
+            .unchecked_into::<NodeMetadataArray>()
     }
 }
 
@@ -1195,22 +1133,22 @@ impl MetadataResponse {
     #[wasm_bindgen(constructor)]
     pub fn new(signer: &Signer, response: &MetadataResponsePayload) -> Self {
         MetadataResponse(nucypher_core::MetadataResponse::new(
-            signer.inner(),
+            signer.as_ref(),
             &response.0,
         ))
     }
 
     #[wasm_bindgen]
-    pub fn verify(&self, verifying_pk: &PublicKey) -> Result<MetadataResponsePayload, JsValue> {
+    pub fn verify(&self, verifying_pk: &PublicKey) -> Result<MetadataResponsePayload, Error> {
         self.0
             .clone()
-            .verify(verifying_pk.inner())
-            .map_err(|_err| Error::new("Failed to verify MetadataResponse").into())
+            .verify(verifying_pk.as_ref())
+            .map_err(|_err| Error::new("Failed to verify MetadataResponse"))
             .map(MetadataResponsePayload)
     }
 
     #[wasm_bindgen(js_name = fromBytes)]
-    pub fn from_bytes(data: &[u8]) -> Result<MetadataResponse, JsValue> {
+    pub fn from_bytes(data: &[u8]) -> Result<MetadataResponse, Error> {
         from_bytes::<_, nucypher_core::MetadataResponse>(data)
     }
 

--- a/nucypher-core-wasm/tests/wasm.rs
+++ b/nucypher-core-wasm/tests/wasm.rs
@@ -1,41 +1,25 @@
-use nucypher_core::Address;
 use nucypher_core_wasm::*;
 
+use js_sys::Uint8Array;
 use umbral_pre::bindings_wasm::{
     generate_kfrags, reencrypt, Capsule, SecretKey, Signer, VerifiedCapsuleFrag, VerifiedKeyFrag,
 };
-use wasm_bindgen::convert::FromWasmAbi;
 use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
 
 //
 // Test utilities
 //
 
-// Downcast a WASM type to a Rust type
-// Reference: https://github.com/rustwasm/wasm-bindgen/issues/2231
-fn of_js_value_generic<T: FromWasmAbi<Abi = u32>>(
-    js: JsValue,
-    classname: &str,
-) -> Result<T, JsValue> {
-    use js_sys::{Object, Reflect};
-    let ctor_name = Object::get_prototype_of(&js).constructor().name();
-    if ctor_name == classname {
-        let ptr = Reflect::get(&js, &JsValue::from_str("ptr"))?;
-        let ptr_u32: u32 = ptr.as_f64().ok_or(JsValue::NULL)? as u32;
-        let value_of_type = unsafe { T::from_abi(ptr_u32) };
-        Ok(value_of_type)
-    } else {
-        Err(JsValue::NULL)
+fn js_option<T>(val: Option<T>) -> JsValue
+where
+    JsValue: From<T>,
+{
+    match val {
+        None => JsValue::NULL,
+        Some(val) => val.into(),
     }
-}
-
-pub fn verified_key_farg_of_js_value(js_value: JsValue) -> Option<VerifiedKeyFrag> {
-    of_js_value_generic(js_value, "VerifiedKeyFrag").unwrap_or(None)
-}
-
-pub fn node_metadata_of_js_value(js_value: JsValue) -> Option<NodeMetadata> {
-    of_js_value_generic(js_value, "NodeMetadata").unwrap_or(None)
 }
 
 fn make_message_kit(
@@ -44,11 +28,13 @@ fn make_message_kit(
     conditions: Option<impl AsRef<str>>,
 ) -> MessageKit {
     let policy_encrypting_key = sk.public_key();
+    let conditions_js = js_option(conditions.map(|s| Conditions::new(s.as_ref().into())));
     MessageKit::new(
         &policy_encrypting_key,
         plaintext,
-        conditions.map(|s| Conditions::new(s.as_ref())),
+        &conditions_js.unchecked_into::<OptionConditions>(),
     )
+    .unwrap()
 }
 
 fn make_hrac() -> HRAC {
@@ -61,22 +47,24 @@ fn make_hrac() -> HRAC {
 fn make_kfrags(delegating_sk: &SecretKey, receiving_sk: &SecretKey) -> Vec<VerifiedKeyFrag> {
     let receiving_pk = receiving_sk.public_key();
     let signer = Signer::new(delegating_sk);
-    let verified_kfrags: Vec<VerifiedKeyFrag> =
-        generate_kfrags(delegating_sk, &receiving_pk, &signer, 2, 3, false, false)
-            .iter()
-            .map(|kfrag| verified_key_farg_of_js_value(kfrag.clone()).unwrap())
-            .collect();
+    let js_kfrags: JsValue =
+        generate_kfrags(delegating_sk, &receiving_pk, &signer, 2, 3, false, false).into();
+    let array_kfrags: js_sys::Array = js_kfrags.dyn_into().unwrap();
+    let verified_kfrags: Vec<VerifiedKeyFrag> = array_kfrags
+        .iter()
+        .map(|js| VerifiedKeyFrag::try_from(&js).unwrap())
+        .collect();
     verified_kfrags
 }
 
 fn make_fleet_state_checksum() -> FleetStateChecksum {
-    let this_node = Some(make_node_metadata());
-    let other_nodes = vec![make_node_metadata(), make_node_metadata()];
-    let mut builder = FleetStateChecksumBuilder::new(this_node);
-    for node in &other_nodes {
-        builder.add_other_node(node);
-    }
-    builder.build()
+    let this_node = js_option(Some(make_node_metadata())).unchecked_into::<OptionNodeMetadata>();
+    let other_nodes = [make_node_metadata(), make_node_metadata()]
+        .into_iter()
+        .map(JsValue::from)
+        .collect::<js_sys::Array>()
+        .unchecked_into::<NodeMetadataArray>();
+    FleetStateChecksum::new(&this_node, &other_nodes).unwrap()
 }
 
 fn make_node_metadata() -> NodeMetadata {
@@ -84,7 +72,7 @@ fn make_node_metadata() -> NodeMetadata {
     // Need to fix it to check the operator address derivation.
     let signing_key = SecretKey::from_bytes(b"01234567890123456789012345678901").unwrap();
 
-    let staking_provider_address = b"00000000000000000001";
+    let staking_provider_address = Address::new(b"00000000000000000001").unwrap();
     let domain = "localhost";
     let timestamp_epoch = 1546300800;
     let verifying_key = signing_key.public_key();
@@ -92,11 +80,14 @@ fn make_node_metadata() -> NodeMetadata {
     let certificate_der = b"certificate_der";
     let host = "https://localhost.com";
     let port = 443;
-    let operator_signature =
-        Some(b"0000000000000000000000000000000100000000000000000000000000000001\x00".to_vec());
+    let operator_signature: Option<Uint8Array> = Some(
+        b"0000000000000000000000000000000100000000000000000000000000000001\x00"
+            .as_ref()
+            .into(),
+    );
 
     let node_metadata_payload = NodeMetadataPayload::new(
-        staking_provider_address,
+        &staking_provider_address,
         domain,
         timestamp_epoch,
         &verifying_key,
@@ -104,7 +95,7 @@ fn make_node_metadata() -> NodeMetadata {
         certificate_der,
         host,
         port,
-        operator_signature,
+        js_option(operator_signature).unchecked_into::<OptionUint8Array>(),
     )
     .unwrap();
 
@@ -114,12 +105,15 @@ fn make_node_metadata() -> NodeMetadata {
 
 fn make_metadata_response_payload() -> (MetadataResponsePayload, Vec<NodeMetadata>) {
     let announce_nodes = vec![make_node_metadata(), make_node_metadata()];
+    let announce_nodes_js = announce_nodes
+        .iter()
+        .cloned()
+        .map(JsValue::from)
+        .collect::<js_sys::Array>()
+        .unchecked_into::<NodeMetadataArray>();
     let timestamp_epoch = 1546300800;
-    let mut payload_builder = MetadataResponsePayloadBuilder::new(timestamp_epoch);
-    for node in &announce_nodes {
-        payload_builder.add_announce_node(node);
-    }
-    (payload_builder.build(), announce_nodes)
+    let payload = MetadataResponsePayload::new(timestamp_epoch, &announce_nodes_js).unwrap();
+    (payload, announce_nodes)
 }
 
 //
@@ -163,23 +157,24 @@ fn message_kit_decrypt_reencrypted() {
     );
 
     // Simulate reencryption on the JS side
-    let vcfrags: Vec<VerifiedCapsuleFrag> = verified_kfrags
+    let vkfrags_array = verified_kfrags.dyn_into::<js_sys::Array>().ok().unwrap();
+    let vcfrags: Vec<VerifiedCapsuleFrag> = vkfrags_array
         .iter()
-        .map(|kfrag| {
-            let kfrag = verified_key_farg_of_js_value(kfrag.clone()).unwrap();
+        .map(|js| {
+            let kfrag = VerifiedKeyFrag::try_from(&js).unwrap();
             reencrypt(&message_kit.capsule(), &kfrag)
         })
         .collect();
-    assert_eq!(vcfrags.len(), verified_kfrags.len());
-
-    let mut mk_with_vcfrags = message_kit.with_vcfrag(&vcfrags[0]);
-    for vcfrag in vcfrags.iter().skip(1) {
-        mk_with_vcfrags.with_vcfrag(vcfrag);
-    }
+    assert_eq!(vcfrags.len(), vkfrags_array.length() as usize);
 
     // Decrypt on the Rust side
-    let decrypted = mk_with_vcfrags
-        .decrypt_reencrypted(&receiving_sk, &delegating_pk)
+    let vcfrags_array = vcfrags
+        .into_iter()
+        .map(JsValue::from)
+        .collect::<js_sys::Array>()
+        .unchecked_into::<VerifiedCapsuleFragArray>();
+    let decrypted = message_kit
+        .decrypt_reencrypted(&receiving_sk, &delegating_pk, &vcfrags_array)
         .unwrap();
 
     assert_eq!(
@@ -272,37 +267,43 @@ fn encrypted_to_bytes_from_bytes() {
 fn make_treasure_map(publisher_sk: &SecretKey, receiving_sk: &SecretKey) -> TreasureMap {
     let hrac = make_hrac();
     let vkfrags = make_kfrags(publisher_sk, receiving_sk);
+    let assigned_kfrags = [
+        (
+            Address::new(b"00000000000000000001").unwrap(),
+            (SecretKey::random().public_key(), vkfrags[0].clone()),
+        ),
+        (
+            Address::new(b"00000000000000000002").unwrap(),
+            (SecretKey::random().public_key(), vkfrags[1].clone()),
+        ),
+        (
+            Address::new(b"00000000000000000003").unwrap(),
+            (SecretKey::random().public_key(), vkfrags[2].clone()),
+        ),
+    ];
 
-    // Try the non-consuming variant of builder
-    let mut builder = TreasureMapBuilder::new(
+    let assigned_kfrags_js = assigned_kfrags
+        .into_iter()
+        .map(|(address, (pk, vkfrag))| {
+            let pair = [JsValue::from(pk), JsValue::from(vkfrag)]
+                .into_iter()
+                .collect::<js_sys::Array>();
+            let entry = [JsValue::from(address), JsValue::from(pair)]
+                .into_iter()
+                .collect::<js_sys::Array>();
+            JsValue::from(entry)
+        })
+        .collect::<js_sys::Array>()
+        .unchecked_into::<AssignedKeyFragsArray>();
+
+    TreasureMap::new(
         &Signer::new(publisher_sk),
         &hrac,
         &SecretKey::random().public_key(),
+        &assigned_kfrags_js,
         2,
     )
     .unwrap()
-    .add_kfrag(
-        b"00000000000000000001",
-        &SecretKey::random().public_key(),
-        &vkfrags[0].clone(),
-    )
-    .unwrap();
-
-    // Also try using the consuming variant of builder:
-    builder
-        .add_kfrag(
-            b"00000000000000000002",
-            &SecretKey::random().public_key(),
-            &vkfrags[1].clone(),
-        )
-        .unwrap()
-        .add_kfrag(
-            b"00000000000000000003",
-            &SecretKey::random().public_key(),
-            &vkfrags[2].clone(),
-        )
-        .unwrap()
-        .build()
 }
 
 #[wasm_bindgen_test]
@@ -331,15 +332,30 @@ fn treasure_map_destinations() {
     let receiving_sk = SecretKey::random();
 
     let treasure_map = make_treasure_map(&publisher_sk, &receiving_sk);
-    let destinations = treasure_map.destinations().unwrap();
-    let destinations: Vec<(Address, EncryptedKeyFrag)> =
-        serde_wasm_bindgen::from_value(destinations).unwrap();
+    let destinations_map = treasure_map
+        .destinations()
+        .dyn_into::<js_sys::Array>()
+        .ok()
+        .unwrap();
+
+    let mut destinations = Vec::new();
+    for entry in destinations_map.iter() {
+        let key_value = entry.dyn_into::<js_sys::Array>().unwrap();
+        let address = Address::try_from(&key_value.get(0)).unwrap();
+        let ekfrag = EncryptedKeyFrag::try_from(&key_value.get(1)).unwrap();
+        destinations.push((address, ekfrag));
+    }
 
     assert!(destinations.len() == 3, "Destinations does not match");
     (0..destinations.len()).for_each(|i| {
         assert_eq!(
             destinations[i].0.as_ref(),
-            format!("0000000000000000000{}", i + 1).as_bytes(),
+            &nucypher_core::Address::new(
+                format!("0000000000000000000{}", i + 1)
+                    .as_bytes()
+                    .try_into()
+                    .unwrap()
+            ),
             "Destination does not match"
         );
     });
@@ -381,21 +397,26 @@ fn reencryption_request_from_bytes_to_bytes() {
     let signer = Signer::new(&publisher_sk);
     let verified_kfrags = make_kfrags(&publisher_sk, &receiving_sk);
     let encrypted_kfrag = EncryptedKeyFrag::new(&signer, &receiving_pk, &hrac, &verified_kfrags[0]);
-    let conditions = Some(Conditions::new("{'some': 'condition'}"));
-    let context = Some(Context::new("{'user': 'context'}"));
+    let conditions: JsValue = Some(Conditions::new("{'some': 'condition'}")).into();
+    let context: JsValue = Some(Context::new("{'user': 'context'}")).into();
+
+    let capsule_array = [capsules[0]]
+        .into_iter()
+        .map(JsValue::from)
+        .collect::<js_sys::Array>()
+        .unchecked_into::<CapsuleArray>();
 
     // Make reencryption request
-    let reencryption_request = ReencryptionRequestBuilder::new(
+    let reencryption_request = ReencryptionRequest::new(
+        &capsule_array,
         &hrac,
         &encrypted_kfrag,
         &publisher_sk.public_key(),
         &receiving_pk,
-        conditions,
-        context,
+        &conditions.unchecked_into::<OptionConditions>(),
+        &context.unchecked_into::<OptionContext>(),
     )
-    .unwrap()
-    .add_capsule(&capsules[0])
-    .build();
+    .unwrap();
 
     assert_eq!(
         reencryption_request,
@@ -432,43 +453,47 @@ fn reencryption_response_verify() {
     // Simulate the reencryption
     let cfrags: Vec<VerifiedCapsuleFrag> = kfrags
         .iter()
-        .map(|kfrag| reencrypt(&capsules[0], kfrag))
+        .map(|kfrag| reencrypt(&capsules[0], &kfrag))
         .collect();
 
     // Make the reencryption response
     let ursula_sk = SecretKey::random();
     let signer = Signer::new(&ursula_sk);
-    let mut builder = ReencryptionResponseBuilder::new(&signer);
-    for cfrag in &cfrags {
-        builder.add_cfrag(cfrag);
-    }
-    for capsule in &capsules {
-        builder.add_capsule(capsule);
-    }
-    let reencryption_response = builder.build();
+
+    let capsules_array = capsules
+        .into_iter()
+        .map(JsValue::from)
+        .collect::<js_sys::Array>()
+        .unchecked_into::<CapsuleArray>();
+    let cfrags_array = cfrags
+        .iter()
+        .cloned()
+        .map(JsValue::from)
+        .collect::<js_sys::Array>()
+        .unchecked_into::<VerifiedCapsuleFragArray>();
+    let reencryption_response =
+        ReencryptionResponse::new(&signer, &capsules_array, &cfrags_array).unwrap();
 
     // Now that the response is created, we're going to "send it" to the client and verify it
 
-    // Add capsule to reencryption response
-    let mut resp_with_capsules = reencryption_response.with_capsule(&capsules[0]);
-    for capsule in &capsules[1..] {
-        resp_with_capsules = resp_with_capsules.with_capsule(capsule);
-    }
-
     // Verify reencryption response
-    let verified_js = resp_with_capsules
+    let verified_array = reencryption_response
         .verify(
+            &capsules_array,
             &alice_sk.public_key(),
             &ursula_sk.public_key(),
             &policy_encrypting_key,
             &bob_sk.public_key(),
         )
+        .unwrap();
+
+    let verified = verified_array
+        .dyn_into::<js_sys::Array>()
+        .ok()
         .unwrap()
-        .into_vec();
-    let verified: Vec<VerifiedCapsuleFrag> = verified_js
-        .into_iter()
-        .map(|vkfrag| serde_wasm_bindgen::from_value(vkfrag).unwrap())
-        .collect();
+        .iter()
+        .map(|js| VerifiedCapsuleFrag::try_from(&js).unwrap())
+        .collect::<Vec<_>>();
 
     assert_eq!(cfrags, verified, "Capsule fragments do not match");
 
@@ -498,29 +523,51 @@ fn retrieval_kit() {
     );
 
     let retrieval_kit_from_mk = RetrievalKit::from_message_kit(&message_kit);
+    let addresses_js: JsValue = retrieval_kit_from_mk.queried_addresses().into();
+    let addresses_from_rkit = addresses_js
+        .dyn_into::<js_sys::Array>()
+        .unwrap()
+        .iter()
+        .map(|js| Address::try_from(&js).unwrap())
+        .collect::<Vec<_>>();
     assert_eq!(
-        retrieval_kit_from_mk.queried_addresses().unwrap().len(),
+        addresses_from_rkit.len(),
         0,
         "Queried addresses length does not match"
     );
 
     let queried_addresses = [
-        b"00000000000000000001",
-        b"00000000000000000002",
-        b"00000000000000000003",
+        Address::new(b"00000000000000000001").unwrap(),
+        Address::new(b"00000000000000000002").unwrap(),
+        Address::new(b"00000000000000000003").unwrap(),
     ];
-    let mut builder = RetrievalKitBuilder::new(&message_kit.capsule(), conditions.clone());
-    for address in queried_addresses {
-        builder.add_queried_address(address).unwrap();
-    }
-    let retreival_kit = builder.build();
+    let queried_addresses_js = queried_addresses
+        .iter()
+        .cloned()
+        .map(JsValue::from)
+        .collect::<js_sys::Array>()
+        .unchecked_into::<AddressArray>();
+    let conditions_js = js_option(conditions).unchecked_into::<OptionConditions>();
+    let retrieval_kit = RetrievalKit::new(
+        &message_kit.capsule(),
+        &queried_addresses_js,
+        &conditions_js,
+    )
+    .unwrap();
+    let addresses_js: JsValue = retrieval_kit.queried_addresses().into();
+    let addresses_from_rkit = addresses_js
+        .dyn_into::<js_sys::Array>()
+        .unwrap()
+        .iter()
+        .map(|js| Address::try_from(&js).unwrap())
+        .collect::<Vec<_>>();
     assert_eq!(
-        retreival_kit.queried_addresses().unwrap().len(),
+        addresses_from_rkit.len(),
         queried_addresses.len(),
         "Queried addresses length does not match"
     );
 
-    let as_bytes = retreival_kit.to_bytes();
+    let as_bytes = retrieval_kit.to_bytes();
     assert_eq!(
         as_bytes,
         RetrievalKit::from_bytes(&as_bytes).unwrap().to_bytes(),
@@ -543,8 +590,9 @@ fn revocation_order() {
     let signer = Signer::new(&delegating_sk);
     let encrypted_kfrag = EncryptedKeyFrag::new(&signer, &receiving_pk, &hrac, &verified_kfrags[0]);
 
-    let ursula_address = b"00000000000000000001";
-    let revocation_order = RevocationOrder::new(&signer, ursula_address, &encrypted_kfrag).unwrap();
+    let ursula_address = Address::new(b"00000000000000000001").unwrap();
+    let revocation_order =
+        RevocationOrder::new(&signer, &ursula_address, &encrypted_kfrag).unwrap();
 
     assert!(revocation_order.verify(&delegating_sk.public_key()).is_ok());
 
@@ -583,9 +631,10 @@ fn node_metadata_derive_operator_address() {
     let node_metadata = make_node_metadata();
     let operator_address = node_metadata.payload().derive_operator_address();
 
-    assert_eq!(
-        operator_address.unwrap(),
-        b"\x01l\xac\x82\x9fj\x06/\r8d\xb5bX\xdd\xc75\xa1\xf9;",
+    assert!(
+        operator_address
+            .unwrap()
+            .equals(&Address::new(b"\x01l\xac\x82\x9fj\x06/\r8d\xb5bX\xdd\xc75\xa1\xf9;").unwrap()),
         "Operator address derivation failed"
     );
 }
@@ -611,19 +660,22 @@ fn fleet_state_checksum_to_bytes() {
 #[wasm_bindgen_test]
 fn metadata_request() {
     let fleet_state_checksum = make_fleet_state_checksum();
-    let announce_nodes = vec![make_node_metadata(), make_node_metadata()];
-
-    let mut builder = MetadataRequestBuilder::new(&fleet_state_checksum);
-    for node in &announce_nodes {
-        builder.add_announce_node(node);
-    }
-    let metadata_request = builder.build();
-
-    let nodes_js = metadata_request.announce_nodes();
-    let nodes: Vec<NodeMetadata> = nodes_js
+    let announce_nodes = [make_node_metadata(), make_node_metadata()];
+    let announce_nodes_js = announce_nodes
         .iter()
         .cloned()
-        .map(|js_node| node_metadata_of_js_value(js_node).unwrap())
+        .map(JsValue::from)
+        .collect::<js_sys::Array>()
+        .unchecked_into::<NodeMetadataArray>();
+
+    let metadata_request = MetadataRequest::new(&fleet_state_checksum, &announce_nodes_js).unwrap();
+
+    let nodes_js: JsValue = metadata_request.announce_nodes().into();
+    let nodes = nodes_js
+        .dyn_into::<js_sys::Array>()
+        .unwrap()
+        .iter()
+        .map(|js| NodeMetadata::try_from(&js).unwrap())
         .collect::<Vec<_>>();
     assert_eq!(nodes, announce_nodes);
 
@@ -643,11 +695,14 @@ fn metadata_request() {
 fn metadata_response_payload() {
     let (metadata_response_payload, announce_nodes) = make_metadata_response_payload();
 
-    let nodes_js = metadata_response_payload.announce_nodes();
+    let nodes_js = metadata_response_payload
+        .announce_nodes()
+        .dyn_into::<js_sys::Array>()
+        .ok()
+        .unwrap();
     let nodes: Vec<NodeMetadata> = nodes_js
         .iter()
-        .cloned()
-        .map(|js_node| node_metadata_of_js_value(js_node).unwrap())
+        .map(|js_node| NodeMetadata::try_from(&js_node).unwrap())
         .collect::<Vec<_>>();
     assert_eq!(nodes, announce_nodes, "Announce nodes does not match");
 }

--- a/nucypher-core/Cargo.toml
+++ b/nucypher-core/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-umbral-pre = { version = "0.6", features = ["serde-support"] }
+umbral-pre = { version = "0.7.0-alpha.0", features = ["serde-support"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 generic-array = "0.14"
 typenum = "1.14"

--- a/nucypher-core/src/node_metadata.rs
+++ b/nucypher-core/src/node_metadata.rs
@@ -80,7 +80,7 @@ pub const RECOVERABLE_SIGNATURE_SIZE: usize = recoverable::SIZE;
 
 /// Node metadata.
 #[serde_as]
-#[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 pub struct NodeMetadataPayload {
     /// The staking provider's Ethereum address.
     pub staking_provider_address: Address,
@@ -125,7 +125,7 @@ impl NodeMetadataPayload {
 }
 
 /// Signed node metadata.
-#[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 pub struct NodeMetadata {
     signature: Signature,
     /// Authorized metadata payload.
@@ -185,7 +185,7 @@ impl<'a> ProtocolObjectInner<'a> for NodeMetadata {
 impl<'a> ProtocolObject<'a> for NodeMetadata {}
 
 /// A request for metadata exchange.
-#[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 pub struct MetadataRequest {
     /// The checksum of the requester's fleet state.
     pub fleet_state_checksum: FleetStateChecksum,
@@ -228,7 +228,7 @@ impl<'a> ProtocolObjectInner<'a> for MetadataRequest {
 impl<'a> ProtocolObject<'a> for MetadataRequest {}
 
 /// Payload of the metadata response.
-#[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 pub struct MetadataResponsePayload {
     /// The timestamp of the most recent fleet state
     /// (the one consisting of the nodes that are being sent).
@@ -253,7 +253,7 @@ impl MetadataResponsePayload {
 }
 
 /// A response returned by an Ursula containing known node metadata.
-#[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 pub struct MetadataResponse {
     signature: Signature,
     payload: MetadataResponsePayload,


### PR DESCRIPTION
- Use a workaround with `wasm-bindgen-derive` to support `Option<&T>` and `Vec<&T>` arguments, and `Vec<T>` and tuple return values, with correct TypeScript annotations
- Remove the instances of Builder pattern and the use of `serde` for argument passing.
- Use `Address` instead of plain bytes in arguments and return values (both in WASM and Python bindgins). Export the `Address` type.
- Use `js_sys::Error` instead of just `JsValue` in results.
- Rust-side and JS-side WASM tests updated
- Added JS-side tests to CI
- Exported `Address` in `__init__.py`
