### PR TITLE
Take an iterable of capsule and vcfrag in `ReencryptionResponse` constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use a workaround with `wasm-bindgen-derive` to support `Option<&T>` and `Vec<&T>` arguments, and `Vec<T>` and tuple return values, with correct TypeScript annotations. Removed all the Builder pattern helper classes. (#[34])
 - Use `Address` instead of plain bytes in arguments and return values (both in WASM and Python bindgins). Export the `Address` type. (#[34])
 - `umbral-pre` dependency bumped to 0.7. (#[36])
+- `ReencryptionResponse::new()` now takes an iterator of pairs `(Capsule, VerifiedCapsuleFrag)` instead of two separate iterators; bindings changed correspondingly. (#[37])
 
 
 ### Added
@@ -32,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#33]: https://github.com/nucypher/nucypher-core/pull/33
 [#34]: https://github.com/nucypher/nucypher-core/pull/34
 [#36]: https://github.com/nucypher/nucypher-core/pull/36
+[#37]: https://github.com/nucypher/nucypher-core/pull/37
 
 
 ## [0.4.0-alpha.0] - 2022-09-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `Address` instead of plain bytes in arguments and return values (both in WASM and Python bindgins). Export the `Address` type. (#[34])
 - `umbral-pre` dependency bumped to 0.7. (#[36])
 - `ReencryptionResponse::new()` now takes an iterator of pairs `(Capsule, VerifiedCapsuleFrag)` instead of two separate iterators; bindings changed correspondingly. (#[37])
+- Change `Iterable` to `Sequence` in Python binding type stubs: bindings cannot actually take just iterables. (#[37])
 
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `umbral-pre` dependency bumped to 0.7. (#[36])
 - `ReencryptionResponse::new()` now takes an iterator of pairs `(Capsule, VerifiedCapsuleFrag)` instead of two separate iterators; bindings changed correspondingly. (#[37])
 - Change `Iterable` to `Sequence` in Python binding type stubs: bindings cannot actually take just iterables. (#[37])
+- `AuthorizedKeyFrag.verify()`, `ReencryptionResponse.verify()`, and `AuthorizedTreasureMap.verify()` now consume `self`. (#[37])
 
 
 ### Added

--- a/nucypher-core-python/nucypher_core/__init__.pyi
+++ b/nucypher-core-python/nucypher_core/__init__.pyi
@@ -210,7 +210,7 @@ class ReencryptionRequest:
 
 class ReencryptionResponse:
 
-    def __init__(self, signer: Signer, capsules: Iterable[Capsule], vcfrags: Iterable[VerifiedCapsuleFrag]):
+    def __init__(self, signer: Signer, capsules_and_vcfrags: Iterable[Tuple[Capsule, VerifiedCapsuleFrag]]):
         ...
 
     def verify(

--- a/nucypher-core-python/nucypher_core/__init__.pyi
+++ b/nucypher-core-python/nucypher_core/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import List, Dict, Iterable, Optional, Mapping, Tuple, Set
+from typing import List, Dict, Sequence, Optional, Mapping, Tuple, Set
 
 from .umbral import SecretKey, PublicKey, Signer, Capsule, VerifiedKeyFrag, VerifiedCapsuleFrag
 
@@ -65,7 +65,7 @@ class MessageKit:
         self,
         sk: SecretKey,
         policy_encrypting_key: PublicKey,
-        vcfrags: Iterable[VerifiedCapsuleFrag]
+        vcfrags: Sequence[VerifiedCapsuleFrag]
     ) -> bytes:
         ...
 
@@ -176,7 +176,7 @@ class ReencryptionRequest:
 
     def __init__(
         self,
-        capsules: Iterable[Capsule],
+        capsules: Sequence[Capsule],
         hrac: HRAC,
         encrypted_kfrag: EncryptedKeyFrag,
         publisher_verifying_key: PublicKey,
@@ -210,12 +210,12 @@ class ReencryptionRequest:
 
 class ReencryptionResponse:
 
-    def __init__(self, signer: Signer, capsules_and_vcfrags: Iterable[Tuple[Capsule, VerifiedCapsuleFrag]]):
+    def __init__(self, signer: Signer, capsules_and_vcfrags: Sequence[Tuple[Capsule, VerifiedCapsuleFrag]]):
         ...
 
     def verify(
         self,
-        capsules: Iterable[Capsule],
+        capsules: Sequence[Capsule],
         alice_verifying_key: PublicKey,
         ursula_verifying_key: PublicKey,
         policy_encrypting_key: PublicKey,
@@ -341,7 +341,7 @@ class NodeMetadata:
 
 class FleetStateChecksum:
 
-    def __init__(self, this_node: Optional[NodeMetadata], other_nodes: Iterable[NodeMetadata]):
+    def __init__(self, this_node: Optional[NodeMetadata], other_nodes: Sequence[NodeMetadata]):
         ...
 
 
@@ -350,7 +350,7 @@ class MetadataRequest:
     def __init__(
         self,
         fleet_state_checksum: FleetStateChecksum,
-        announce_nodes: Iterable[NodeMetadata],
+        announce_nodes: Sequence[NodeMetadata],
     ):
         ...
 
@@ -368,7 +368,7 @@ class MetadataRequest:
 
 class MetadataResponsePayload:
 
-    def __init__(self, timestamp_epoch: int, announce_nodes: Iterable[NodeMetadata]):
+    def __init__(self, timestamp_epoch: int, announce_nodes: Sequence[NodeMetadata]):
         ...
 
     timestamp_epoch: int

--- a/nucypher-core-python/src/lib.rs
+++ b/nucypher-core-python/src/lib.rs
@@ -605,6 +605,7 @@ impl ReencryptionResponse {
             .collect::<Vec<_>>();
         let vcfrags_backend = self
             .backend
+            .clone()
             .verify(
                 &capsules_backend,
                 alice_verifying_key.as_ref(),

--- a/nucypher-core-python/src/lib.rs
+++ b/nucypher-core-python/src/lib.rs
@@ -573,20 +573,20 @@ pub struct ReencryptionResponse {
 #[pymethods]
 impl ReencryptionResponse {
     #[new]
-    pub fn new(signer: &Signer, capsules: Vec<Capsule>, vcfrags: Vec<VerifiedCapsuleFrag>) -> Self {
-        let capsules_backend = capsules
+    pub fn new(signer: &Signer, capsules_and_vcfrags: Vec<(Capsule, VerifiedCapsuleFrag)>) -> Self {
+        let (capsules_backend, vcfrags_backend): (Vec<_>, Vec<_>) = capsules_and_vcfrags
             .into_iter()
-            .map(umbral_pre::Capsule::from)
-            .collect::<Vec<_>>();
-        let vcfrags_backend = vcfrags
-            .into_iter()
-            .map(umbral_pre::VerifiedCapsuleFrag::from)
-            .collect::<Vec<_>>();
+            .map(|(capsule, vcfrag)| {
+                (
+                    umbral_pre::Capsule::from(capsule),
+                    umbral_pre::VerifiedCapsuleFrag::from(vcfrag),
+                )
+            })
+            .unzip();
         ReencryptionResponse {
             backend: nucypher_core::ReencryptionResponse::new(
                 signer.as_ref(),
-                &capsules_backend,
-                vcfrags_backend,
+                capsules_backend.iter().zip(vcfrags_backend.into_iter()),
             ),
         }
     }

--- a/nucypher-core-wasm/src/lib.rs
+++ b/nucypher-core-wasm/src/lib.rs
@@ -695,6 +695,7 @@ impl ReencryptionResponse {
             .collect::<Vec<_>>();
         let backend_vcfrags = self
             .0
+            .clone()
             .verify(
                 &backend_capsules,
                 alice_verifying_key.as_ref(),

--- a/nucypher-core/src/key_frag.rs
+++ b/nucypher-core/src/key_frag.rs
@@ -39,7 +39,7 @@ impl AuthorizedKeyFrag {
         Self { signature, kfrag }
     }
 
-    fn verify(&self, hrac: &HRAC, publisher_verifying_key: &PublicKey) -> Option<VerifiedKeyFrag> {
+    fn verify(self, hrac: &HRAC, publisher_verifying_key: &PublicKey) -> Option<VerifiedKeyFrag> {
         if !self
             .signature
             .verify(publisher_verifying_key, &signed_message(hrac, &self.kfrag))
@@ -49,7 +49,7 @@ impl AuthorizedKeyFrag {
 
         // Ursula has no side channel to get the KeyFrag author's key,
         // so verifying the keyfrag is useless.
-        Some(self.kfrag.clone().skip_verification())
+        Some(self.kfrag.skip_verification())
     }
 }
 

--- a/nucypher-core/src/key_frag.rs
+++ b/nucypher-core/src/key_frag.rs
@@ -1,5 +1,6 @@
 use alloc::boxed::Box;
 use alloc::string::String;
+use alloc::vec::Vec;
 use core::fmt;
 
 use serde::{Deserialize, Serialize};
@@ -21,6 +22,10 @@ struct AuthorizedKeyFrag {
     kfrag: KeyFrag,
 }
 
+fn signed_message(hrac: &HRAC, kfrag: &KeyFrag) -> Vec<u8> {
+    [hrac.as_ref(), kfrag.to_array().as_ref()].concat()
+}
+
 impl AuthorizedKeyFrag {
     fn new(signer: &Signer, hrac: &HRAC, verified_kfrag: VerifiedKeyFrag) -> Self {
         // Alice makes plain to Ursula that, upon decrypting this message,
@@ -29,16 +34,16 @@ impl AuthorizedKeyFrag {
         // TODO (rust-umbral#73): add VerifiedKeyFrag::unverify()?
         let kfrag = verified_kfrag.unverify();
 
-        let signature = signer.sign(&[hrac.as_ref(), kfrag.to_array().as_ref()].concat());
+        let signature = signer.sign(&signed_message(hrac, &kfrag));
 
         Self { signature, kfrag }
     }
 
     fn verify(&self, hrac: &HRAC, publisher_verifying_key: &PublicKey) -> Option<VerifiedKeyFrag> {
-        if !self.signature.verify(
-            publisher_verifying_key,
-            &[hrac.as_ref(), self.kfrag.to_array().as_ref()].concat(),
-        ) {
+        if !self
+            .signature
+            .verify(publisher_verifying_key, &signed_message(hrac, &self.kfrag))
+        {
             return None;
         }
 

--- a/nucypher-core/src/reencryption.rs
+++ b/nucypher-core/src/reencryption.rs
@@ -126,18 +126,19 @@ fn signed_message(capsules: &[Capsule], cfrags: &[CapsuleFrag]) -> Vec<u8> {
 
 impl ReencryptionResponse {
     /// Creates and signs a new reencryption response.
-    pub fn new(
+    pub fn new<'a>(
         signer: &Signer,
-        capsules: &[Capsule],
-        vcfrags: impl IntoIterator<Item = VerifiedCapsuleFrag>,
+        capsules_and_vcfrags: impl IntoIterator<Item = (&'a Capsule, VerifiedCapsuleFrag)>,
     ) -> Self {
+        let (capsules, vcfrags): (Vec<_>, Vec<_>) = capsules_and_vcfrags.into_iter().unzip();
+
         // un-verify
         let cfrags: Vec<_> = vcfrags
             .into_iter()
             .map(|vcfrag| vcfrag.unverify())
             .collect();
 
-        let signature = signer.sign(&signed_message(capsules, &cfrags));
+        let signature = signer.sign(&signed_message(&capsules, &cfrags));
 
         ReencryptionResponse {
             cfrags: cfrags.into_boxed_slice(),

--- a/nucypher-core/src/reencryption.rs
+++ b/nucypher-core/src/reencryption.rs
@@ -148,7 +148,7 @@ impl ReencryptionResponse {
 
     /// Verifies the reencryption response and returns the contained kfrags on success.
     pub fn verify(
-        &self,
+        self,
         capsules: &[Capsule],
         alice_verifying_key: &PublicKey,
         ursula_verifying_key: &PublicKey,
@@ -170,8 +170,8 @@ impl ReencryptionResponse {
 
         let vcfrags = self
             .cfrags
-            .iter()
-            .cloned()
+            .into_vec()
+            .into_iter()
             .zip(capsules.iter())
             .map(|(cfrag, capsule)| {
                 cfrag.verify(

--- a/nucypher-core/src/treasure_map.rs
+++ b/nucypher-core/src/treasure_map.rs
@@ -141,7 +141,7 @@ impl AuthorizedTreasureMap {
     }
 
     fn verify(
-        &self,
+        self,
         recipient_key: &PublicKey,
         publisher_verifying_key: &PublicKey,
     ) -> Option<TreasureMap> {
@@ -151,7 +151,7 @@ impl AuthorizedTreasureMap {
         if !self.signature.verify(publisher_verifying_key, &message) {
             return None;
         }
-        Some(self.treasure_map.clone())
+        Some(self.treasure_map)
     }
 }
 


### PR DESCRIPTION
- Take an iterable of `(Capsule, VerifiedCapsuleFrag)` tuples `ReencryptionResponse::new()` (and change bindings correspondingly)
- Replace `Iterable` with `Sequence` in Python bindgins: PyO3 cannot take generators as parameters.
- `AuthorizedKeyFrag.verify()`, `ReencryptionResponse.verify()`, and `AuthorizedTreasureMap.verify()` now consume `self`, to match Umbral and the other `nucypher-core`'s `verify()` methods. 