### PR TITLE
Make the remaining methods returning Addresses strictly typed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Under construction.
+### Fixed
+
+- Finish up introducing Address type in the spots forgotten in #[34]. Namely, in Python bindings: in `TreasureMap.destinations()`, in `RetrievalKit.queried_addresses()`, and in `NodeMetadata.staking_provider_address()`. (#[38])
+
+
+[#38]: https://github.com/nucypher/nucypher-core/pull/38
 
 
 ## [0.4.0] - 2022-10-02

--- a/nucypher-core-python/src/lib.rs
+++ b/nucypher-core-python/src/lib.rs
@@ -381,11 +381,11 @@ impl TreasureMap {
     }
 
     #[getter]
-    fn destinations(&self) -> BTreeMap<&[u8], EncryptedKeyFrag> {
+    fn destinations(&self) -> BTreeMap<Address, EncryptedKeyFrag> {
         let mut result = BTreeMap::new();
         for (address, ekfrag) in &self.backend.destinations {
             result.insert(
-                address.as_ref(),
+                Address { backend: *address },
                 EncryptedKeyFrag {
                     backend: ekfrag.clone(),
                 },
@@ -675,11 +675,11 @@ impl RetrievalKit {
     }
 
     #[getter]
-    fn queried_addresses(&self) -> BTreeSet<&[u8]> {
+    fn queried_addresses(&self) -> BTreeSet<Address> {
         self.backend
             .queried_addresses
             .iter()
-            .map(|address| address.as_ref())
+            .map(|address| Address { backend: *address })
             .collect::<BTreeSet<_>>()
     }
 
@@ -800,8 +800,10 @@ impl NodeMetadataPayload {
     }
 
     #[getter]
-    fn staking_provider_address(&self) -> &[u8] {
-        self.backend.staking_provider_address.as_ref()
+    fn staking_provider_address(&self) -> Address {
+        Address {
+            backend: self.backend.staking_provider_address,
+        }
     }
 
     #[getter]


### PR DESCRIPTION
Finish up introducing `Address` type in the spots forgotten in #34. Namely, in Python bindings:
- in `TreasureMap.destinations()`
- in `RetrievalKit.queried_addresses()`
- in `NodeMetadata.staking_provider_address()`