### PR TITLE
Update for the changed umbral-pre API

### DIFF
--- a/.github/workflows/nucypher-core.yml
+++ b/.github/workflows/nucypher-core.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            rust: 1.57 # MSRV
+            rust: 1.63 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
 
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.57 # MSRV
+          - 1.63 # MSRV
           - stable
         target:
           - wasm32-unknown-unknown
@@ -64,7 +64,7 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - run: cargo install wasm-pack
-      - run: wasm-pack test --node
+      - run: cd ../nucypher-core-wasm && wasm-pack test --node
 
   yarn-test:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Under construction.
+### Changed
+
+- Bumped MSRV to 1.63. (#[41])
+- Bumped `umbral-pre` to 0.8 (with consequent API changes to the re-exported `umbral_pre` crate), `rmp-serde` to 1.x, `pyo3` to 0.17. (#[41])
+- Major protocol versions bumped to 2 - ABI has changed. (#[41])
+
+
+[#41]: https://github.com/nucypher/nucypher-core/pull/38
 
 
 ## [0.4.1] - 2022-10-22

--- a/nucypher-core-python/Cargo.toml
+++ b/nucypher-core-python/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = "0.16"
+pyo3 = "0.17"
 nucypher-core = { path = "../nucypher-core" }
-umbral-pre = { version = "0.7.0", features = ["bindings-python"] }
+umbral-pre = { version = "0.8", features = ["bindings-python"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "as_ref"] }
 
 [build-dependencies]

--- a/nucypher-core-python/nucypher_core/umbral.pyi
+++ b/nucypher-core-python/nucypher_core/umbral.pyi
@@ -10,15 +10,11 @@ class SecretKey:
     def public_key(self) -> PublicKey:
         ...
 
-    def to_secret_bytes(self) -> bytes:
+    def to_be_bytes(self) -> bytes:
         ...
 
     @staticmethod
-    def from_bytes(data: bytes) -> SecretKey:
-        ...
-
-    @staticmethod
-    def serialized_size() -> int:
+    def from_be_bytes(data: bytes) -> SecretKey:
         ...
 
 
@@ -36,35 +32,27 @@ class SecretKeyFactory:
     def from_secure_randomness(seed: bytes) -> SecretKeyFactory:
         ...
 
+    def make_secret(self, label: bytes) -> bytes:
+        ...
+
     def make_key(self, label: bytes) -> SecretKey:
         ...
 
     def make_factory(self, label: bytes) -> SecretKeyFactory:
         ...
 
-    def to_secret_bytes(self) -> bytes:
-        ...
-
     @staticmethod
-    def from_bytes(data: bytes) -> SecretKeyFactory:
-        ...
-
-    @staticmethod
-    def serialized_size() -> int:
+    def from_secure_randomness(data: bytes) -> SecretKeyFactory:
         ...
 
 
 class PublicKey:
 
     @staticmethod
-    def from_bytes(data: bytes) -> PublicKey:
+    def from_compressed_bytes(data: bytes) -> PublicKey:
         ...
 
-    def __bytes__(self) -> bytes:
-        ...
-
-    @staticmethod
-    def serialized_size() -> int:
+    def to_compressed_bytes(self) -> bytes:
         ...
 
 
@@ -86,22 +74,14 @@ class Signature:
         ...
 
     @staticmethod
-    def from_bytes(data: bytes) -> Signature:
+    def from_der_bytes(data: bytes) -> Signature:
         ...
 
-    def __bytes__(self) -> bytes:
-        ...
-
-    @staticmethod
-    def serialized_size() -> int:
+    def to_der_bytes(self) -> bytes:
         ...
 
 
 class Capsule:
-
-    @staticmethod
-    def serialized_size() -> int:
-        ...
 
     @staticmethod
     def from_bytes(data: bytes) -> Capsule:
@@ -131,24 +111,13 @@ class KeyFrag:
     def __bytes__(self) -> bytes:
         ...
 
-    @staticmethod
-    def serialized_size() -> int:
-        ...
-
 
 class VerifiedKeyFrag:
-
-    def from_verified_bytes(self, data: bytes) -> VerifiedKeyFrag:
-        ...
 
     def __bytes__(self) -> bytes:
         ...
 
     def unverify(self) -> KeyFrag:
-        ...
-
-    @staticmethod
-    def serialized_size() -> int:
         ...
 
 
@@ -185,25 +154,13 @@ class CapsuleFrag:
     def __bytes__(self) -> bytes:
         ...
 
-    @staticmethod
-    def serialized_size() -> int:
-        ...
-
 
 class VerifiedCapsuleFrag:
-
-    @staticmethod
-    def from_verified_bytes(data: bytes) -> VerifiedCapsuleFrag:
-        ...
 
     def __bytes__(self) -> bytes:
         ...
 
     def unverify(self) -> CapsuleFrag:
-        ...
-
-    @staticmethod
-    def serialized_size() -> int:
         ...
 
 

--- a/nucypher-core-python/src/lib.rs
+++ b/nucypher-core-python/src/lib.rs
@@ -212,7 +212,7 @@ impl MessageKit {
 
     #[getter]
     fn capsule(&self) -> Capsule {
-        self.backend.capsule.into()
+        self.backend.capsule.clone().into()
     }
 
     #[getter]
@@ -671,7 +671,7 @@ impl RetrievalKit {
 
     #[getter]
     fn capsule(&self) -> Capsule {
-        self.backend.capsule.into()
+        self.backend.capsule.clone().into()
     }
 
     #[getter]

--- a/nucypher-core-wasm/Cargo.toml
+++ b/nucypher-core-wasm/Cargo.toml
@@ -19,15 +19,14 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-umbral-pre = { version = "0.7.0", features = ["bindings-wasm"] }
+umbral-pre = { version = "0.8", features = ["bindings-wasm"] }
 nucypher-core = { path = "../nucypher-core" }
 wasm-bindgen = "0.2.74"
 js-sys = "0.3.51"
-ethereum-types = "0.12.1"
-console_error_panic_hook = { version = "0.1.6", optional = true }
+console_error_panic_hook = { version = "0.1", optional = true }
 derive_more = { version = "0.99", default-features = false, features = ["from", "as_ref"] }
 wasm-bindgen-derive = "0.1"
 
 [dev-dependencies]
-console_error_panic_hook = "0.1.7"
+console_error_panic_hook = "0.1"
 wasm-bindgen-test = "0.3.28"

--- a/nucypher-core-wasm/examples/node/src/main.test.ts
+++ b/nucypher-core-wasm/examples/node/src/main.test.ts
@@ -296,11 +296,11 @@ describe("ReencryptionRequest", () => {
 
     expect(reencryptionRequest).toBeTruthy();
     expect(reencryptionRequest.hrac.toBytes()).toEqual(hrac.toBytes());
-    expect(reencryptionRequest.publisherVerifyingKey.toBytes()).toEqual(
-      delegatingPk.toBytes()
+    expect(reencryptionRequest.publisherVerifyingKey.toCompressedBytes()).toEqual(
+      delegatingPk.toCompressedBytes()
     );
-    expect(reencryptionRequest.bobVerifyingKey.toBytes()).toEqual(
-      recipientPk.toBytes()
+    expect(reencryptionRequest.bobVerifyingKey.toCompressedBytes()).toEqual(
+      recipientPk.toCompressedBytes()
     );
     expect(reencryptionRequest.encryptedKfrag.toBytes()).toEqual(
       encryptedKeyFrag.toBytes()

--- a/nucypher-core-wasm/src/lib.rs
+++ b/nucypher-core-wasm/src/lib.rs
@@ -262,7 +262,7 @@ impl MessageKit {
 
     #[wasm_bindgen(getter)]
     pub fn capsule(&self) -> Capsule {
-        Capsule::from(self.0.capsule)
+        Capsule::from(self.0.capsule.clone())
     }
 
     #[wasm_bindgen(getter)]
@@ -691,7 +691,7 @@ impl ReencryptionResponse {
         let typed_capsules = try_from_js_array::<Capsule>(capsules)?;
         let backend_capsules = typed_capsules
             .into_iter()
-            .map(|capsule| *capsule.as_ref())
+            .map(|capsule| capsule.as_ref().clone())
             .collect::<Vec<_>>();
         let backend_vcfrags = self
             .0
@@ -754,7 +754,7 @@ impl RetrievalKit {
 
     #[wasm_bindgen(getter)]
     pub fn capsule(&self) -> Capsule {
-        Capsule::from(self.0.capsule)
+        Capsule::from(self.0.capsule.clone())
     }
 
     #[wasm_bindgen(getter, js_name = queriedAddresses)]

--- a/nucypher-core-wasm/tests/wasm.rs
+++ b/nucypher-core-wasm/tests/wasm.rs
@@ -81,7 +81,7 @@ fn make_fleet_state_checksum() -> FleetStateChecksum {
 fn make_node_metadata() -> NodeMetadata {
     // Just a random valid key.
     // Need to fix it to check the operator address derivation.
-    let signing_key = SecretKey::from_bytes(b"01234567890123456789012345678901").unwrap();
+    let signing_key = SecretKey::from_be_bytes(b"01234567890123456789012345678901").unwrap();
 
     let staking_provider_address = Address::new(b"00000000000000000001").unwrap();
     let domain = "localhost";
@@ -390,7 +390,7 @@ fn reencryption_request_from_bytes_to_bytes() {
     let conditions: JsValue = Some(Conditions::new("{'some': 'condition'}")).into();
     let context: JsValue = Some(Context::new("{'user': 'context'}")).into();
 
-    let capsule_array = into_js_array([capsules[0]]);
+    let capsule_array = into_js_array([capsules[0].clone()]);
 
     // Make reencryption request
     let reencryption_request = ReencryptionRequest::new(

--- a/nucypher-core/Cargo.toml
+++ b/nucypher-core/Cargo.toml
@@ -10,12 +10,11 @@ readme = "README.md"
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-umbral-pre = { version = "0.7.0", features = ["serde-support"] }
+umbral-pre = { version = "0.8", features = ["serde-support"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 generic-array = "0.14"
-typenum = "1.14"
 sha3 = "0.10"
-rmp-serde = "0.15"
+rmp-serde = "1"
 k256 = { version = "0.11", default-features = false, features = ["ecdsa"]}
 signature = "1.5"
 serde_with = "1.14"

--- a/nucypher-core/src/address.rs
+++ b/nucypher-core/src/address.rs
@@ -1,11 +1,11 @@
-use generic_array::sequence::Split;
-use generic_array::GenericArray;
-use k256::elliptic_curve::sec1::ToEncodedPoint;
-use k256::Secp256k1;
+use generic_array::{
+    sequence::Split,
+    typenum::{U12, U20},
+    GenericArray,
+};
+use k256::{elliptic_curve::sec1::ToEncodedPoint, Secp256k1};
 use serde::{Deserialize, Serialize};
-use sha3::{Digest, Keccak256};
-use signature::digest::Update;
-use typenum::{U12, U20};
+use sha3::{digest::Update, Digest, Keccak256};
 use umbral_pre::serde_bytes;
 
 // We could use the third-party `ethereum_types::Address` here,

--- a/nucypher-core/src/hrac.rs
+++ b/nucypher-core/src/hrac.rs
@@ -1,12 +1,9 @@
 use core::fmt;
 
-use generic_array::sequence::Split;
-use generic_array::GenericArray;
+use generic_array::{sequence::Split, typenum::U16, GenericArray};
 use serde::{Deserialize, Serialize};
-use sha3::{Digest, Keccak256};
-use signature::digest::Update;
-use typenum::U16;
-use umbral_pre::{serde_bytes, PublicKey, SerializableToArray};
+use sha3::{digest::Update, Digest, Keccak256};
+use umbral_pre::{serde_bytes, PublicKey};
 
 /// "hashed resource access code".
 ///
@@ -32,8 +29,8 @@ impl HRAC {
         label: &[u8],
     ) -> Self {
         let digest = Keccak256::new()
-            .chain(publisher_verifying_key.to_array())
-            .chain(bob_verifying_key.to_array())
+            .chain(publisher_verifying_key.to_compressed_bytes())
+            .chain(bob_verifying_key.to_compressed_bytes())
             .chain(label)
             .finalize();
 

--- a/nucypher-core/src/key_frag.rs
+++ b/nucypher-core/src/key_frag.rs
@@ -6,8 +6,7 @@ use core::fmt;
 use serde::{Deserialize, Serialize};
 use umbral_pre::{
     decrypt_original, encrypt, serde_bytes, Capsule, DecryptionError as UmbralDecryptionError,
-    EncryptionError, KeyFrag, PublicKey, SecretKey, SerializableToArray, Signature, Signer,
-    VerifiedKeyFrag,
+    EncryptionError, KeyFrag, PublicKey, SecretKey, Signature, Signer, VerifiedKeyFrag,
 };
 
 use crate::hrac::HRAC;
@@ -23,7 +22,7 @@ struct AuthorizedKeyFrag {
 }
 
 fn signed_message(hrac: &HRAC, kfrag: &KeyFrag) -> Vec<u8> {
-    [hrac.as_ref(), kfrag.to_array().as_ref()].concat()
+    [hrac.as_ref(), messagepack_serialize(kfrag).as_ref()].concat()
 }
 
 impl AuthorizedKeyFrag {
@@ -59,7 +58,7 @@ impl<'a> ProtocolObjectInner<'a> for AuthorizedKeyFrag {
     }
 
     fn version() -> (u16, u16) {
-        (1, 0)
+        (2, 0)
     }
 
     fn unversioned_to_bytes(&self) -> Box<[u8]> {
@@ -151,7 +150,7 @@ impl<'a> ProtocolObjectInner<'a> for EncryptedKeyFrag {
     }
 
     fn version() -> (u16, u16) {
-        (1, 0)
+        (2, 0)
     }
 
     fn unversioned_to_bytes(&self) -> Box<[u8]> {

--- a/nucypher-core/src/message_kit.rs
+++ b/nucypher-core/src/message_kit.rs
@@ -67,20 +67,13 @@ impl MessageKit {
     }
 }
 
-#[derive(Deserialize)]
-struct MessageKit0 {
-    capsule: Capsule,
-    #[serde(with = "serde_bytes::as_base64")]
-    ciphertext: Box<[u8]>,
-}
-
 impl<'a> ProtocolObjectInner<'a> for MessageKit {
     fn brand() -> [u8; 4] {
         *b"MKit"
     }
 
     fn version() -> (u16, u16) {
-        (1, 1)
+        (2, 0)
     }
 
     fn unversioned_to_bytes(&self) -> Box<[u8]> {
@@ -88,17 +81,10 @@ impl<'a> ProtocolObjectInner<'a> for MessageKit {
     }
 
     fn unversioned_from_bytes(minor_version: u16, bytes: &[u8]) -> Option<Result<Self, String>> {
-        match minor_version {
-            0 => {
-                let mkit = messagepack_deserialize::<MessageKit0>(bytes).map(|mkit| MessageKit {
-                    capsule: mkit.capsule,
-                    ciphertext: mkit.ciphertext,
-                    conditions: None,
-                });
-                Some(mkit)
-            }
-            1 => Some(messagepack_deserialize(bytes)),
-            _ => None,
+        if minor_version == 0 {
+            Some(messagepack_deserialize(bytes))
+        } else {
+            None
         }
     }
 }

--- a/nucypher-core/src/node_metadata.rs
+++ b/nucypher-core/src/node_metadata.rs
@@ -8,7 +8,7 @@ use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use serde_with::serde_as;
 use sha3::{Digest, Keccak256};
 use signature::digest::Update;
-use umbral_pre::{serde_bytes, PublicKey, SerializableToArray, Signature, Signer};
+use umbral_pre::{serde_bytes, PublicKey, Signature, Signer};
 
 use crate::address::Address;
 use crate::fleet_state::FleetStateChecksum;
@@ -116,7 +116,7 @@ impl NodeMetadataPayload {
         let signature = self
             .operator_signature
             .ok_or(AddressDerivationError::NoSignatureInPayload)?;
-        let message = encode_defunct(&self.verifying_key.to_array());
+        let message = encode_defunct(&self.verifying_key.to_compressed_bytes());
         let key = signature
             .recover_verifying_key_from_digest(message)
             .map_err(AddressDerivationError::RecoveryFailed)?;
@@ -166,7 +166,7 @@ impl<'a> ProtocolObjectInner<'a> for NodeMetadata {
         // since the whole payload is signed (so we can't just substitute the default).
         // Alternatively, one can add new fields to `NodeMetadata` itself
         // (but then they won't be signed).
-        (1, 0)
+        (2, 0)
     }
 
     fn unversioned_to_bytes(&self) -> Box<[u8]> {
@@ -209,7 +209,7 @@ impl<'a> ProtocolObjectInner<'a> for MetadataRequest {
     }
 
     fn version() -> (u16, u16) {
-        (1, 0)
+        (2, 0)
     }
 
     fn unversioned_to_bytes(&self) -> Box<[u8]> {
@@ -295,7 +295,7 @@ impl<'a> ProtocolObjectInner<'a> for MetadataResponse {
         // since the whole payload is signed (so we can't just substitute the default).
         // Alternatively, one can add new fields to `NodeMetadata` itself
         // (but then they won't be signed).
-        (1, 0)
+        (2, 0)
     }
 
     fn unversioned_to_bytes(&self) -> Box<[u8]> {

--- a/nucypher-core/src/revocation_order.rs
+++ b/nucypher-core/src/revocation_order.rs
@@ -65,7 +65,7 @@ impl<'a> ProtocolObjectInner<'a> for RevocationOrder {
     }
 
     fn version() -> (u16, u16) {
-        (1, 0)
+        (2, 0)
     }
 
     fn unversioned_to_bytes(&self) -> Box<[u8]> {

--- a/nucypher-core/src/versioning.rs
+++ b/nucypher-core/src/versioning.rs
@@ -27,7 +27,7 @@ pub(crate) fn messagepack_deserialize<'a, T>(bytes: &'a [u8]) -> Result<T, Strin
 where
     T: Deserialize<'a>,
 {
-    rmp_serde::from_read_ref(bytes).map_err(|err| format!("{}", err))
+    rmp_serde::from_slice(bytes).map_err(|err| format!("{}", err))
 }
 
 struct ProtocolObjectHeader {


### PR DESCRIPTION
`umbral-pre` switched to using `serde` throughout (https://github.com/nucypher/rust-umbral/pull/110), which changes the ABI of protocol objects here.

- Bumped `umbral-pre` to 0.8, `rmp-serde` to 1.x, `pyo3` to 0.17
- Bumped MSRV to 1.63 because the compilers before can't derive some types in some generic constructions in `nucypher-core-wasm/src/lib.rs`.
- Major protocol versions bumped
- Updated `umbral.pyi`
- Updates for the changes in `umbral-pre` API
- Using `messagepack_serialize()` as the standard serialization for signing purposes

