### PR TITLE
Renames branch master -> main

### DIFF
--- a/.github/workflows/nucypher-core.yml
+++ b/.github/workflows/nucypher-core.yml
@@ -9,7 +9,7 @@ on:
       - "Cargo.*"
   push:
     branches:
-      - master
+      - main
     tags:
       - v*
 

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -6,7 +6,7 @@ on:
       - README.md
   push:
     branches:
-      - master
+      - main
     paths-ignore:
       - README.md
     tags:

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -17,7 +17,7 @@ The version number part (major/minor/patch) that is bumped should correspond to 
 - Use Python [Bumpversion](https://github.com/c4urself/bump2version/) to autmoatically update relevant version strings throughout the repo.
   - `bump2version <major/minor/patch> --new-version <major>.<minor>.<patch>`
 - git push the commit and tag
-  - `git push upstream master --tags`
+  - `git push upstream main --tags`
 
 
 

--- a/README.md
+++ b/README.md
@@ -2,18 +2,18 @@
 
 This repo contains Rust implementation of the protocol classes that can be shared between Python and JS clients/servers of the network.
 
-* [Rust](https://github.com/nucypher/nucypher-core/tree/master/nucypher-core) (primary) [![crate][rust-crate-image]][rust-crate-link] [![Docs][rust-docs-image]][rust-docs-link] ![License][rust-license-image] [![Build Status][rust-build-image]][rust-build-link] [![Coverage][rust-coverage-image]][rust-coverage-link]
-* [JavaScript](https://github.com/nucypher/nucypher-core/tree/master/nucypher-core-wasm) (WASM-based) [![npm package][js-npm-image]][js-npm-link] ![License][js-license-image]
-* [Python](https://github.com/nucypher/nucypher-core/tree/master/nucypher-core-python) [![pypi package][pypi-image]][pypi-link] [![Docs][rtd-image]][rtd-link] ![License][pypi-license-image]
+* [Rust](https://github.com/nucypher/nucypher-core/tree/main/nucypher-core) (primary) [![crate][rust-crate-image]][rust-crate-link] [![Docs][rust-docs-image]][rust-docs-link] ![License][rust-license-image] [![Build Status][rust-build-image]][rust-build-link] [![Coverage][rust-coverage-image]][rust-coverage-link]
+* [JavaScript](https://github.com/nucypher/nucypher-core/tree/main/nucypher-core-wasm) (WASM-based) [![npm package][js-npm-image]][js-npm-link] ![License][js-license-image]
+* [Python](https://github.com/nucypher/nucypher-core/tree/main/nucypher-core-python) [![pypi package][pypi-image]][pypi-link] [![Docs][rtd-image]][rtd-link] ![License][pypi-license-image]
 
 [rust-crate-image]: https://img.shields.io/crates/v/nucypher-core.svg
 [rust-crate-link]: https://crates.io/crates/nucypher-core
 [rust-docs-image]: https://docs.rs/nucypher-core/badge.svg
 [rust-docs-link]: https://docs.rs/nucypher-core/
 [rust-license-image]: https://img.shields.io/crates/l/nucypher-core
-[rust-build-image]: https://github.com/nucypher/nucypher-core/workflows/nucypher-core/badge.svg?branch=master&event=push
+[rust-build-image]: https://github.com/nucypher/nucypher-core/workflows/nucypher-core/badge.svg?branch=main&event=push
 [rust-build-link]: https://github.com/nucypher/nucypher-core/actions?query=workflow%3Anucypher-core
-[rust-coverage-image]: https://codecov.io/gh/nucypher/nucypher-core/branch/master/graph/badge.svg
+[rust-coverage-image]: https://codecov.io/gh/nucypher/nucypher-core/branch/main/graph/badge.svg
 [rust-coverage-link]: https://codecov.io/gh/nucypher/nucypher-core
 [js-npm-image]: https://img.shields.io/npm/v/@nucypher/nucypher-core
 [js-npm-link]: https://www.npmjs.com/package/@nucypher/nucypher-core

--- a/nucypher-core-python/README.md
+++ b/nucypher-core-python/README.md
@@ -15,4 +15,4 @@ You will need to have `setuptools-rust` installed. Then, for development you can
 [pypi-license-image]: https://img.shields.io/pypi/l/nucypher-core
 [rtd-image]: https://readthedocs.org/projects/nucypher-core/badge/?version=latest
 [rtd-link]: https://nucypher-core.readthedocs.io/en/latest/
-[nucypher-core]: https://github.com/nucypher/nucypher-core/tree/master/nucypher-core
+[nucypher-core]: https://github.com/nucypher/nucypher-core/tree/main/nucypher-core

--- a/nucypher-core-python/setup.py
+++ b/nucypher-core-python/setup.py
@@ -13,7 +13,7 @@ setup(
     version="0.6.1",
     author="Bogdan Opanchuk",
     author_email="bogdan@opanchuk.net",
-    url="https://github.com/nucypher/nucypher-core/tree/master/nucypher-core-python",
+    url="https://github.com/nucypher/nucypher-core/tree/main/nucypher-core-python",
     rust_extensions=[RustExtension("nucypher_core._nucypher_core", binding=Binding.PyO3, debug=False)],
     packages=["nucypher_core"],
     package_data = {

--- a/nucypher-core-wasm/Cargo.toml
+++ b/nucypher-core-wasm/Cargo.toml
@@ -8,7 +8,7 @@ authors = [
 edition = "2021"
 license = "GPL-3.0-only"
 description = "NuCypher network core data structures"
-repository = "https://github.com/nucypher/nucypher-core/tree/master/nucypher-core-wasm"
+repository = "https://github.com/nucypher/nucypher-core/tree/main/nucypher-core-wasm"
 readme = "README.md"
 categories = ["cryptography", "no-std"]
 

--- a/nucypher-core-wasm/package.template.json
+++ b/nucypher-core-wasm/package.template.json
@@ -9,7 +9,7 @@
   "license": "GPL-3.0-only",
   "repository": {
     "type": "git",
-    "url": "https://github.com/nucypher/nucypher-core/tree/master/nucypher-core-wasm"
+    "url": "https://github.com/nucypher/nucypher-core/tree/main/nucypher-core-wasm"
   },
   "files": [
     "pkg-node/*.wasm",

--- a/nucypher-core/Cargo.toml
+++ b/nucypher-core/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Bogdan Opanchuk <bogdan@opanchuk.net>"]
 edition = "2021"
 license = "GPL-3.0-only"
 description = "Nucypher network core datastructures"
-repository = "https://github.com/nucypher/nucypher-core/tree/master/nucypher-core"
+repository = "https://github.com/nucypher/nucypher-core/tree/main/nucypher-core"
 readme = "README.md"
 categories = ["cryptography", "no-std"]
 

--- a/nucypher-core/README.md
+++ b/nucypher-core/README.md
@@ -14,15 +14,15 @@
 
 Bindings for several languages are available:
 
-* [JavaScript](https://github.com/nucypher/nucypher-core/tree/master/nucypher-core-wasm) (WASM-based)
-* [Python](https://github.com/nucypher/nucypher-core/tree/master/nucypher-core-python)
+* [JavaScript](https://github.com/nucypher/nucypher-core/tree/main/nucypher-core-wasm) (WASM-based)
+* [Python](https://github.com/nucypher/nucypher-core/tree/main/nucypher-core-python)
 
 [crate-image]: https://img.shields.io/crates/v/nucypher-core.svg
 [crate-link]: https://crates.io/crates/nucypher-core
 [docs-image]: https://docs.rs/nucypher-core/badge.svg
 [docs-link]: https://docs.rs/nucypher-core/
 [license-image]: https://img.shields.io/crates/l/nucypher-core
-[build-image]: https://github.com/nucypher/nucypher-core/workflows/nucypher-core/badge.svg?branch=master&event=push
+[build-image]: https://github.com/nucypher/nucypher-core/workflows/nucypher-core/badge.svg?branch=main&event=push
 [build-link]: https://github.com/nucypher/nucypher-core/actions?query=workflow%3Anucypher-core
-[coverage-image]: https://codecov.io/gh/nucypher/nucypher-core/branch/master/graph/badge.svg
+[coverage-image]: https://codecov.io/gh/nucypher/nucypher-core/branch/main/graph/badge.svg
 [coverage-link]: https://codecov.io/gh/nucypher/nucypher-core


### PR DESCRIPTION
Fixes some leftover references to `master` in the GitHub actions configuration and documentation.