### PR TITLE
Clarify Ferveo variant usage in docs

### DIFF
--- a/nucypher-core/src/dkg.rs
+++ b/nucypher-core/src/dkg.rs
@@ -13,9 +13,9 @@ use crate::versioning::{
 /// The ferveo variant to use for the decryption share derivation.
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Copy, Clone)]
 pub enum FerveoVariant {
-    /// the simple variant requires n/n shares to decrypt
+    /// The simple variant requires m of n shares to decrypt
     SIMPLE,
-    /// the precomputed variant requires m/n shares to decrypt
+    /// The precomputed variant requires n of n shares to decrypt
     PRECOMPUTED,
 }
 


### PR DESCRIPTION
- Tests failing for the same reason #52 used to fail. Let's merge #52 in, and rebase this PR over it.
- Alternatively we can just merge it since it's a docstring change 