### PR TITLE
Fix a typo in Ferveo type stubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## 0.9.1 - Unreleased
+
+### Fixed
+
+- Fixed a typo in the Python type stubs for `ferveo.Keypair.secure_randomness_size()`. ([#61])
+
+
+[#61]: https://github.com/nucypher/nucypher-core/pull/61
+
+
 ## [0.9.0] - 2023-6-23
 
 ### Added

--- a/nucypher-core-python/nucypher_core/ferveo.pyi
+++ b/nucypher-core-python/nucypher_core/ferveo.pyi
@@ -11,7 +11,7 @@ class Keypair:
         ...
 
     @staticmethod
-    def secure_randomness_size(data: bytes) -> int:
+    def secure_randomness_size() -> int:
         ...
 
     @staticmethod


### PR DESCRIPTION
**Type of PR:**
- Bugfix

**Required reviews:** 
- 1

**What this does:**
- Fixes a typo in the stub for `Keypair.secure_randomness_size()`
