### PR TITLE
Use custom (de)serialization for SessionStaticKey into bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,22 +4,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## 0.9.1 - Unreleased
+## 0.10.0 - Unreleased
 
 ### Changed
 
-- Removed `DkgPublicParams` from bindings. ([ferveo#127])
+- Custom (de)serialization of `SessionStaticKey` to bytestring instead of vector of integers. ([#63])
+- Removed `DkgPublicParams` from bindings. ([#66])
 
-### Fixed
-
-- Fixed a typo in the Python type stubs for `ferveo.Keypair.secure_randomness_size()`. ([#61])
 
 ### Added
 
 - Added `equals` method to protocol objects in WASM bindings ([#56])
 
-[ferveo#127]: https://github.com/nucypher/nucypher-core/pull/127
+
+### Fixed
+
+- Fixed a typo in the Python type stubs for `ferveo.Keypair.secure_randomness_size()`. ([#61])
+
+
+[#56]: https://github.com/nucypher/nucypher-core/pull/56
 [#61]: https://github.com/nucypher/nucypher-core/pull/61
+[#63]: https://github.com/nucypher/nucypher-core/pull/63
+[#66]: https://github.com/nucypher/nucypher-core/pull/66
 
 
 ## [0.9.0] - 2023-6-23


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
`SessionStaticKey` protocol objects had varied lengths due to serialization to vector of integers instead of bytestrings. This fixes that.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
