### PR TITLE
Fix missing `ValidatorMessage` stub in Python bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Custom (de)serialization of `SessionStaticKey` to bytestring instead of vector of integers. ([#63])
+- Replaced raw tuples with `ValidatorMessage` in Python bindings. ([#65])
 - Removed `DkgPublicParams` from bindings. ([#66])
 
 
@@ -25,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#56]: https://github.com/nucypher/nucypher-core/pull/56
 [#61]: https://github.com/nucypher/nucypher-core/pull/61
 [#63]: https://github.com/nucypher/nucypher-core/pull/63
+[#65]: https://github.com/nucypher/nucypher-core/pull/65
 [#66]: https://github.com/nucypher/nucypher-core/pull/66
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,7 +505,7 @@ dependencies = [
 [[package]]
 name = "ferveo-common-pre-release"
 version = "0.1.0-alpha.0"
-source = "git+https://github.com/nucypher/ferveo.git?rev=ccdc20990ed3ad6ed8267e5dc54745a3a500b730#ccdc20990ed3ad6ed8267e5dc54745a3a500b730"
+source = "git+https://github.com/nucypher/ferveo.git?rev=0d4e973e007b16cff34d649ae107608c809349af#0d4e973e007b16cff34d649ae107608c809349af"
 dependencies = [
  "ark-ec",
  "ark-serialize",
@@ -520,7 +520,7 @@ dependencies = [
 [[package]]
 name = "ferveo-pre-release"
 version = "0.1.0-alpha.8"
-source = "git+https://github.com/nucypher/ferveo.git?rev=ccdc20990ed3ad6ed8267e5dc54745a3a500b730#ccdc20990ed3ad6ed8267e5dc54745a3a500b730"
+source = "git+https://github.com/nucypher/ferveo.git?rev=0d4e973e007b16cff34d649ae107608c809349af#0d4e973e007b16cff34d649ae107608c809349af"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -634,7 +634,7 @@ dependencies = [
 [[package]]
 name = "group-threshold-cryptography-pre-release"
 version = "0.1.0-alpha.0"
-source = "git+https://github.com/nucypher/ferveo.git?rev=ccdc20990ed3ad6ed8267e5dc54745a3a500b730#ccdc20990ed3ad6ed8267e5dc54745a3a500b730"
+source = "git+https://github.com/nucypher/ferveo.git?rev=0d4e973e007b16cff34d649ae107608c809349af#0d4e973e007b16cff34d649ae107608c809349af"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -1399,7 +1399,7 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 [[package]]
 name = "subproductdomain-pre-release"
 version = "0.1.0-alpha.0"
-source = "git+https://github.com/nucypher/ferveo.git?rev=ccdc20990ed3ad6ed8267e5dc54745a3a500b730#ccdc20990ed3ad6ed8267e5dc54745a3a500b730"
+source = "git+https://github.com/nucypher/ferveo.git?rev=0d4e973e007b16cff34d649ae107608c809349af#0d4e973e007b16cff34d649ae107608c809349af"
 dependencies = [
  "anyhow",
  "ark-ec",

--- a/nucypher-core-python/Cargo.toml
+++ b/nucypher-core-python/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 pyo3 = "0.18"
 nucypher-core = { path = "../nucypher-core" }
 umbral-pre = { version = "0.10.0", features = ["bindings-python"] }
-ferveo = { package = "ferveo-pre-release", version = "0.1.0-alpha.8", features = ["bindings-python"], git = "https://github.com/nucypher/ferveo.git", rev = "ccdc20990ed3ad6ed8267e5dc54745a3a500b730" }
+ferveo = { package = "ferveo-pre-release", version = "0.1.0-alpha.8", features = ["bindings-python"], git = "https://github.com/nucypher/ferveo.git", rev = "0d4e973e007b16cff34d649ae107608c809349af" }
 derive_more = { version = "0.99", default-features = false, features = ["from", "as_ref"] }
 
 [build-dependencies]

--- a/nucypher-core-python/nucypher_core/ferveo.py
+++ b/nucypher-core-python/nucypher_core/ferveo.py
@@ -10,6 +10,7 @@ decrypt_with_shared_secret = _ferveo.decrypt_with_shared_secret
 
 Validator = _ferveo.Validator
 Transcript = _ferveo.Transcript
+ValidatorMessage = _ferveo.ValidatorMessage
 Dkg = _ferveo.Dkg
 Ciphertext = _ferveo.Ciphertext
 DecryptionShareSimple = _ferveo.DecryptionShareSimple

--- a/nucypher-core-python/nucypher_core/ferveo.pyi
+++ b/nucypher-core-python/nucypher_core/ferveo.pyi
@@ -1,4 +1,4 @@
-from typing import Sequence, Tuple
+from typing import Sequence
 
 
 class Keypair:
@@ -65,6 +65,19 @@ class DkgPublicKey:
         ...
 
 
+class ValidatorMessage:
+
+    def __init__(
+            self,
+            validator: Validator,
+            transcript: Transcript,
+    ):
+        ...
+
+    validator: Validator
+    transcript: Transcript
+
+
 class Dkg:
 
     def __init__(
@@ -82,7 +95,7 @@ class Dkg:
     def generate_transcript(self) -> Transcript:
         ...
 
-    def aggregate_transcripts(self, messages: Sequence[Tuple[Validator, Transcript]]) -> AggregatedTranscript:
+    def aggregate_transcripts(self, messages: Sequence[ValidatorMessage]) -> AggregatedTranscript:
         ...
 
 
@@ -115,10 +128,10 @@ class DecryptionSharePrecomputed:
 
 class AggregatedTranscript:
 
-    def __init__(self, messages: Sequence[Tuple[Validator, Transcript]]):
+    def __init__(self, messages: Sequence[ValidatorMessage]):
         ...
 
-    def verify(self, shares_num: int, messages: Sequence[Tuple[Validator, Transcript]]) -> bool:
+    def verify(self, shares_num: int, messages: Sequence[ValidatorMessage]) -> bool:
         ...
 
     def create_decryption_share_simple(

--- a/nucypher-core-wasm/Cargo.toml
+++ b/nucypher-core-wasm/Cargo.toml
@@ -20,7 +20,7 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 umbral-pre = { version = "0.10.0", features = ["bindings-wasm"] }
-ferveo = { package = "ferveo-pre-release", version = "0.1.0-alpha.8", features = ["bindings-wasm"], git = "https://github.com/nucypher/ferveo.git", rev = "ccdc20990ed3ad6ed8267e5dc54745a3a500b730" }
+ferveo = { package = "ferveo-pre-release", version = "0.1.0-alpha.8", features = ["bindings-wasm"], git = "https://github.com/nucypher/ferveo.git", rev = "0d4e973e007b16cff34d649ae107608c809349af" }
 nucypher-core = { path = "../nucypher-core" }
 wasm-bindgen = "0.2.86"
 js-sys = "0.3.63"

--- a/nucypher-core/Cargo.toml
+++ b/nucypher-core/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 umbral-pre = { version = "0.10.0", features = ["serde"] }
-ferveo = { package = "ferveo-pre-release", version = "0.1.0-alpha.8", git = "https://github.com/nucypher/ferveo.git", rev = "ccdc20990ed3ad6ed8267e5dc54745a3a500b730" }
+ferveo = { package = "ferveo-pre-release", version = "0.1.0-alpha.8", git = "https://github.com/nucypher/ferveo.git", rev = "0d4e973e007b16cff34d649ae107608c809349af" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 generic-array = { version = "0.14", features = ["zeroize"] }
 sha3 = "0.10"

--- a/nucypher-core/src/conditions.rs
+++ b/nucypher-core/src/conditions.rs
@@ -28,7 +28,7 @@ impl From<String> for Conditions {
 
 impl fmt::Display for Conditions {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Conditions({})", self.0)
+        write!(f, "{}", self.0)
     }
 }
 
@@ -57,6 +57,6 @@ impl From<String> for Context {
 
 impl fmt::Display for Context {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Context({})", self.0)
+        write!(f, "{}", self.0)
     }
 }


### PR DESCRIPTION
**Type of PR:**
- Bugfix

**Required reviews:** 
- 1

**What this does:**
- Replaces tuple usage with a concrete `ValidatorMessage` type in Python Bindings

**Issues fixed/closed:**
- Refers to: https://github.com/nucypher/ferveo/issues/129
- Closes: https://github.com/nucypher/nucypher-core/issues/62

**Why it's needed:**
- To fix the corresponding issue. See: https://github.com/nucypher/ferveo/pull/131

**Notes for reviewers:**
- Uses changes from [an unreleased `ferveo` version](https://github.com/nucypher/ferveo/commit/4aeda15dd749694416f62fda0504f64bcbe2b444)
- This PR closes https://github.com/nucypher/nucypher-core/issues/62 since the `ferveo` version used is the child of the changes mentioned in the issue
