### PR TITLE
Use `ferveo-pre-release@0.1.0-alpha.10`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,7 +505,8 @@ dependencies = [
 [[package]]
 name = "ferveo-common-pre-release"
 version = "0.1.0-alpha.0"
-source = "git+https://github.com/nucypher/ferveo.git?rev=0d4e973e007b16cff34d649ae107608c809349af#0d4e973e007b16cff34d649ae107608c809349af"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a03b0fdd554fcec312af62f105ea5820c00191faaedd3b0331ff6f7581337db7"
 dependencies = [
  "ark-ec",
  "ark-serialize",
@@ -519,8 +520,9 @@ dependencies = [
 
 [[package]]
 name = "ferveo-pre-release"
-version = "0.1.0-alpha.8"
-source = "git+https://github.com/nucypher/ferveo.git?rev=0d4e973e007b16cff34d649ae107608c809349af#0d4e973e007b16cff34d649ae107608c809349af"
+version = "0.1.0-alpha.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68aa171e2311fe6cdefb2d3fc253a1551e4eb3710c4e3876582bc9b03c6e9d29"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -634,7 +636,8 @@ dependencies = [
 [[package]]
 name = "group-threshold-cryptography-pre-release"
 version = "0.1.0-alpha.0"
-source = "git+https://github.com/nucypher/ferveo.git?rev=0d4e973e007b16cff34d649ae107608c809349af#0d4e973e007b16cff34d649ae107608c809349af"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3de2158ab5d2651720f4913144ebd5cb77e60268ff2dff05433db76063025ca"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -1399,7 +1402,8 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 [[package]]
 name = "subproductdomain-pre-release"
 version = "0.1.0-alpha.0"
-source = "git+https://github.com/nucypher/ferveo.git?rev=0d4e973e007b16cff34d649ae107608c809349af#0d4e973e007b16cff34d649ae107608c809349af"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b53446b638d1c20006bbe8076edd41141200741dabc0a80d434fc5c4a356de9"
 dependencies = [
  "anyhow",
  "ark-ec",

--- a/nucypher-core-python/Cargo.toml
+++ b/nucypher-core-python/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 pyo3 = "0.18"
 nucypher-core = { path = "../nucypher-core" }
 umbral-pre = { version = "0.10.0", features = ["bindings-python"] }
-ferveo = { package = "ferveo-pre-release", version = "0.1.0-alpha.8", features = ["bindings-python"], git = "https://github.com/nucypher/ferveo.git", rev = "0d4e973e007b16cff34d649ae107608c809349af" }
+ferveo = { package = "ferveo-pre-release", version = "0.1.0-alpha.10", features = ["bindings-python"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "as_ref"] }
 
 [build-dependencies]

--- a/nucypher-core-wasm/Cargo.toml
+++ b/nucypher-core-wasm/Cargo.toml
@@ -20,7 +20,7 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 umbral-pre = { version = "0.10.0", features = ["bindings-wasm"] }
-ferveo = { package = "ferveo-pre-release", version = "0.1.0-alpha.8", features = ["bindings-wasm"], git = "https://github.com/nucypher/ferveo.git", rev = "0d4e973e007b16cff34d649ae107608c809349af" }
+ferveo = { package = "ferveo-pre-release", version = "0.1.0-alpha.10", features = ["bindings-wasm"] }
 nucypher-core = { path = "../nucypher-core" }
 wasm-bindgen = "0.2.86"
 js-sys = "0.3.63"

--- a/nucypher-core/Cargo.toml
+++ b/nucypher-core/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 umbral-pre = { version = "0.10.0", features = ["serde"] }
-ferveo = { package = "ferveo-pre-release", version = "0.1.0-alpha.8", git = "https://github.com/nucypher/ferveo.git", rev = "0d4e973e007b16cff34d649ae107608c809349af" }
+ferveo = { package = "ferveo-pre-release", version = "0.1.0-alpha.10" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 generic-array = { version = "0.14", features = ["zeroize"] }
 sha3 = "0.10"


### PR DESCRIPTION
**Type of PR:**
-  Other

**Required reviews:** 
- 1

**What this does:**
- Replace GH dependency with a crate

