### PR TITLE
Tracking changes for `ferveo-pre-release@0.3.0` update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,15 +505,14 @@ dependencies = [
 [[package]]
 name = "ferveo-common-pre-release"
 version = "0.1.0-alpha.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a03b0fdd554fcec312af62f105ea5820c00191faaedd3b0331ff6f7581337db7"
+source = "git+https://github.com/nucypher/ferveo.git?rev=4939e79fd336a08547984d66dd0f7a256ab9dcf7#4939e79fd336a08547984d66dd0f7a256ab9dcf7"
 dependencies = [
  "ark-ec",
  "ark-serialize",
  "ark-std",
  "bincode",
+ "generic-array",
  "rand 0.8.5",
- "rand_core 0.6.4",
  "serde",
  "serde_with 2.3.3",
 ]
@@ -521,8 +520,7 @@ dependencies = [
 [[package]]
 name = "ferveo-pre-release"
 version = "0.1.0-alpha.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68aa171e2311fe6cdefb2d3fc253a1551e4eb3710c4e3876582bc9b03c6e9d29"
+source = "git+https://github.com/nucypher/ferveo.git?rev=4939e79fd336a08547984d66dd0f7a256ab9dcf7#4939e79fd336a08547984d66dd0f7a256ab9dcf7"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -636,8 +634,7 @@ dependencies = [
 [[package]]
 name = "group-threshold-cryptography-pre-release"
 version = "0.1.0-alpha.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3de2158ab5d2651720f4913144ebd5cb77e60268ff2dff05433db76063025ca"
+source = "git+https://github.com/nucypher/ferveo.git?rev=4939e79fd336a08547984d66dd0f7a256ab9dcf7#4939e79fd336a08547984d66dd0f7a256ab9dcf7"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -876,7 +873,7 @@ checksum = "94c7128ba23c81f6471141b90f17654f89ef44a56e14b8a4dd0fddfccd655277"
 
 [[package]]
 name = "nucypher-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "chacha20poly1305",
  "ferveo-pre-release",
@@ -898,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "nucypher-core-python"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "derive_more",
  "ferveo-pre-release",
@@ -910,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "nucypher-core-wasm"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "console_error_panic_hook",
  "derive_more",
@@ -1402,8 +1399,7 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 [[package]]
 name = "subproductdomain-pre-release"
 version = "0.1.0-alpha.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b53446b638d1c20006bbe8076edd41141200741dabc0a80d434fc5c4a356de9"
+source = "git+https://github.com/nucypher/ferveo.git?rev=4939e79fd336a08547984d66dd0f7a256ab9dcf7#4939e79fd336a08547984d66dd0f7a256ab9dcf7"
 dependencies = [
  "anyhow",
  "ark-ec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,7 +505,7 @@ dependencies = [
 [[package]]
 name = "ferveo-common-pre-release"
 version = "0.1.0-alpha.0"
-source = "git+https://github.com/nucypher/ferveo.git?rev=4939e79fd336a08547984d66dd0f7a256ab9dcf7#4939e79fd336a08547984d66dd0f7a256ab9dcf7"
+source = "git+https://github.com/nucypher/ferveo.git?rev=90c73180f00f8a1122594881ea67f5a75a9fb0b1#90c73180f00f8a1122594881ea67f5a75a9fb0b1"
 dependencies = [
  "ark-ec",
  "ark-serialize",
@@ -520,7 +520,7 @@ dependencies = [
 [[package]]
 name = "ferveo-pre-release"
 version = "0.1.0-alpha.10"
-source = "git+https://github.com/nucypher/ferveo.git?rev=4939e79fd336a08547984d66dd0f7a256ab9dcf7#4939e79fd336a08547984d66dd0f7a256ab9dcf7"
+source = "git+https://github.com/nucypher/ferveo.git?rev=90c73180f00f8a1122594881ea67f5a75a9fb0b1#90c73180f00f8a1122594881ea67f5a75a9fb0b1"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -634,7 +634,7 @@ dependencies = [
 [[package]]
 name = "group-threshold-cryptography-pre-release"
 version = "0.1.0-alpha.0"
-source = "git+https://github.com/nucypher/ferveo.git?rev=4939e79fd336a08547984d66dd0f7a256ab9dcf7#4939e79fd336a08547984d66dd0f7a256ab9dcf7"
+source = "git+https://github.com/nucypher/ferveo.git?rev=90c73180f00f8a1122594881ea67f5a75a9fb0b1#90c73180f00f8a1122594881ea67f5a75a9fb0b1"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -1399,7 +1399,7 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 [[package]]
 name = "subproductdomain-pre-release"
 version = "0.1.0-alpha.0"
-source = "git+https://github.com/nucypher/ferveo.git?rev=4939e79fd336a08547984d66dd0f7a256ab9dcf7#4939e79fd336a08547984d66dd0f7a256ab9dcf7"
+source = "git+https://github.com/nucypher/ferveo.git?rev=90c73180f00f8a1122594881ea67f5a75a9fb0b1#90c73180f00f8a1122594881ea67f5a75a9fb0b1"
 dependencies = [
  "anyhow",
  "ark-ec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
+checksum = "6340df57935414636969091153f35f68d9f00bbc8fb4a9c6054706c213e6c6bc"
 
 [[package]]
 name = "core-foundation-sys"
@@ -306,9 +306,9 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.7"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
@@ -338,17 +338,30 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.0.0-rc.2"
+version = "4.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d928d978dbec61a1167414f5ec534f24bea0d7a0d24dd9b6233d3d8223e585"
+checksum = "436ace70fc06e06f7f689d2624dc4e2f0ea666efb5aa704215f7249ae6e047a7"
 dependencies = [
  "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
  "fiat-crypto",
- "packed_simd_2",
  "platforms",
+ "rustc_version",
  "serde",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -396,7 +409,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.18",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -418,14 +431,14 @@ checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
  "darling_core 0.20.1",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.23",
 ]
 
 [[package]]
 name = "der"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56acb310e15652100da43d130af8d97b509e95af61aab1c5a7939ef24337ee17"
+checksum = "0c7ed52955ce76b1554f509074bb357d3fb8ac9b51288a65a3fd480d1dfba946"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -504,8 +517,9 @@ dependencies = [
 
 [[package]]
 name = "ferveo-common-pre-release"
-version = "0.1.0-alpha.0"
-source = "git+https://github.com/nucypher/ferveo.git?rev=90c73180f00f8a1122594881ea67f5a75a9fb0b1#90c73180f00f8a1122594881ea67f5a75a9fb0b1"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81b88f694e924a2878d4abf89b79df44cdee2e0670875aba885bb769ccd71be3"
 dependencies = [
  "ark-ec",
  "ark-serialize",
@@ -519,8 +533,9 @@ dependencies = [
 
 [[package]]
 name = "ferveo-pre-release"
-version = "0.1.0-alpha.10"
-source = "git+https://github.com/nucypher/ferveo.git?rev=90c73180f00f8a1122594881ea67f5a75a9fb0b1#90c73180f00f8a1122594881ea67f5a75a9fb0b1"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58661702af7320b5e643e34f41a1528db32ee7faa92b6294e93feff307f52e41"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -533,7 +548,7 @@ dependencies = [
  "derive_more",
  "ferveo-common-pre-release",
  "generic-array",
- "getrandom 0.2.9",
+ "getrandom 0.2.10",
  "group-threshold-cryptography-pre-release",
  "hex",
  "itertools",
@@ -598,26 +613,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "ghost"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77ac7b51b8e6313251737fcef4b1c01a2ea102bde68415b62c0ee9268fec357"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.18",
 ]
 
 [[package]]
@@ -633,8 +637,9 @@ dependencies = [
 
 [[package]]
 name = "group-threshold-cryptography-pre-release"
-version = "0.1.0-alpha.0"
-source = "git+https://github.com/nucypher/ferveo.git?rev=90c73180f00f8a1122594881ea67f5a75a9fb0b1#90c73180f00f8a1122594881ea67f5a75a9fb0b1"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ade4859b58171e6815b0641e23f615f5dab030ecf2376b069d652f323fa760b"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -699,9 +704,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -766,12 +771,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0539b5de9241582ce6bd6b0ba7399313560151e58c9aaf8b74b711b1bdce644"
-dependencies = [
- "ghost",
-]
+checksum = "c38a87a1e0e2752433cd4b26019a469112a25fb43b30f5ee9b3b898925c5a0f9"
 
 [[package]]
 name = "itertools"
@@ -784,15 +786,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a"
 
 [[package]]
 name = "js-sys"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -820,21 +822,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
-
-[[package]]
-name = "libm"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -842,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "measure_time"
@@ -901,7 +897,7 @@ dependencies = [
  "ferveo-pre-release",
  "nucypher-core",
  "pyo3",
- "pyo3-build-config",
+ "pyo3-build-config 0.19.1",
  "umbral-pre",
 ]
 
@@ -954,25 +950,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
-name = "packed_simd_2"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
-dependencies = [
- "cfg-if",
- "libm",
-]
 
 [[package]]
 name = "parking_lot"
@@ -986,22 +972,22 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-targets",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+checksum = "b4b27ab7be369122c218afc2079489cdcb4b517c0a3fc386ff11e1fedfcc2b35"
 
 [[package]]
 name = "platforms"
@@ -1028,9 +1014,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]
@@ -1047,7 +1033,7 @@ dependencies = [
  "libc",
  "memoffset",
  "parking_lot",
- "pyo3-build-config",
+ "pyo3-build-config 0.18.3",
  "pyo3-ffi",
  "pyo3-macros",
  "unindent",
@@ -1064,13 +1050,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyo3-build-config"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "554db24f0b3c180a9c0b1268f91287ab3f17c162e15b54caaae5a6b3773396b0"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
 name = "pyo3-ffi"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd4d7c5337821916ea2a1d21d1092e8443cf34879e53a0ac653fbb98f44ff65c"
 dependencies = [
  "libc",
- "pyo3-build-config",
+ "pyo3-build-config 0.18.3",
 ]
 
 [[package]]
@@ -1098,9 +1094,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -1164,7 +1160,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.9",
+ "getrandom 0.2.10",
 ]
 
 [[package]]
@@ -1178,9 +1174,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags",
 ]
@@ -1228,9 +1224,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9"
 
 [[package]]
 name = "scoped-tls"
@@ -1265,38 +1261,38 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.163"
+version = "1.0.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+checksum = "7daf513456463b42aa1d94cff7e0c24d682b429f020b9afa4f5ba5c40a22b237"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
+checksum = "5a16be4fe5320ade08736447e3198294a5ea9a6d44dde6f35f0a5e06859c427a"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.163"
+version = "1.0.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+checksum = "b69b106b68bc8054f0e974e70d19984040f8a5cf9215ca82626ea4853f82c4b9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.23",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "0f1e14e89be7aa4c4b78bdbdc9eb5bf8517829a600ae8eaa39a6e1d960b5185c"
 dependencies = [
  "itoa",
  "ryu",
@@ -1350,14 +1346,14 @@ dependencies = [
  "darling 0.20.1",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.23",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1376,9 +1372,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
+checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 dependencies = [
  "digest",
  "rand_core 0.6.4",
@@ -1386,9 +1382,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "strsim"
@@ -1398,8 +1394,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subproductdomain-pre-release"
-version = "0.1.0-alpha.0"
-source = "git+https://github.com/nucypher/ferveo.git?rev=90c73180f00f8a1122594881ea67f5a75a9fb0b1#90c73180f00f8a1122594881ea67f5a75a9fb0b1"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7331c4e4ab9b7c9ed4ad2e950e8760826622c7ab110d9f1b3f350e2005017eab"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -1427,9 +1424,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1438,35 +1435,35 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.7"
+version = "0.12.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd1ba337640d60c3e96bc6f0638a939b9c9a7f2c316a1598c279828b3d1dc8c5"
+checksum = "1b1c7f239eb94671427157bd93b3694320f3668d4e1eff08c7285366fd777fac"
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.23",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.21"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
+checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
 dependencies = [
  "itoa",
  "serde",
@@ -1505,7 +1502,7 @@ dependencies = [
  "chacha20poly1305",
  "derive_more",
  "generic-array",
- "getrandom 0.2.9",
+ "getrandom 0.2.10",
  "hex",
  "hkdf",
  "js-sys",
@@ -1523,9 +1520,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
 
 [[package]]
 name = "unindent"
@@ -1563,9 +1560,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1573,16 +1570,16 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.23",
  "wasm-bindgen-shared",
 ]
 
@@ -1610,9 +1607,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.36"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1985d03709c53167ce907ff394f5316aa22cb4e12761295c5dc57dacb6297e"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1622,9 +1619,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1632,28 +1629,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.23",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e636f3a428ff62b3742ebc3c70e254dfe12b8c2b469d688ea59cdd4abcf502"
+checksum = "6e6e302a7ea94f83a6d09e78e7dc7d9ca7b186bc2829c24a22d0753efd680671"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -1665,9 +1662,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f18c1fad2f7c4958e7bcce014fa212f59a65d5e3721d0f77e6c0b27ede936ba3"
+checksum = "ecb993dd8c836930ed130e020e77d9b2e65dd0fbab1b67c790b0f5d80b11a575"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1675,9 +1672,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1711,53 +1708,23 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets 0.48.0",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1767,21 +1734,9 @@ checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1791,21 +1746,9 @@ checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1815,21 +1758,9 @@ checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1839,9 +1770,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "x25519-dalek"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabd6e16dd08033932fc3265ad4510cc2eab24656058a6dcb107ffe274abcc95"
+checksum = "ec7fae07da688e17059d5886712c933bb0520f15eff2e09cfa18e30968f4e63a"
 dependencies = [
  "curve25519-dalek",
  "rand_core 0.6.4",
@@ -1866,5 +1797,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.23",
 ]

--- a/nucypher-core-python/Cargo.toml
+++ b/nucypher-core-python/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 pyo3 = "0.18"
 nucypher-core = { path = "../nucypher-core" }
 umbral-pre = { version = "0.10.0", features = ["bindings-python"] }
-ferveo = { package = "ferveo-pre-release", version = "0.1.0-alpha.10", features = ["bindings-python"] }
+ferveo = { package = "ferveo-pre-release", version = "0.1.0-alpha.10", features = ["bindings-python"], git = "https://github.com/nucypher/ferveo.git", rev = "4939e79fd336a08547984d66dd0f7a256ab9dcf7" }
 derive_more = { version = "0.99", default-features = false, features = ["from", "as_ref"] }
 
 [build-dependencies]

--- a/nucypher-core-python/Cargo.toml
+++ b/nucypher-core-python/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 pyo3 = "0.18"
 nucypher-core = { path = "../nucypher-core" }
 umbral-pre = { version = "0.10.0", features = ["bindings-python"] }
-ferveo = { package = "ferveo-pre-release", version = "0.1.0-alpha.10", features = ["bindings-python"], git = "https://github.com/nucypher/ferveo.git", rev = "c60ab3e28eef2dadf5502133472dbde44a25375a" }
+ferveo = { package = "ferveo-pre-release", version = "0.1.0-alpha.10", features = ["bindings-python"], git = "https://github.com/nucypher/ferveo.git", rev = "90c73180f00f8a1122594881ea67f5a75a9fb0b1" }
 derive_more = { version = "0.99", default-features = false, features = ["from", "as_ref"] }
 
 [build-dependencies]

--- a/nucypher-core-python/Cargo.toml
+++ b/nucypher-core-python/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 pyo3 = "0.18"
 nucypher-core = { path = "../nucypher-core" }
 umbral-pre = { version = "0.10.0", features = ["bindings-python"] }
-ferveo = { package = "ferveo-pre-release", version = "0.1.0-alpha.10", features = ["bindings-python"], git = "https://github.com/nucypher/ferveo.git", rev = "90c73180f00f8a1122594881ea67f5a75a9fb0b1" }
+ferveo = { package = "ferveo-pre-release", version = "0.2.0", features = ["bindings-python"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "as_ref"] }
 
 [build-dependencies]

--- a/nucypher-core-python/Cargo.toml
+++ b/nucypher-core-python/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 pyo3 = "0.18"
 nucypher-core = { path = "../nucypher-core" }
 umbral-pre = { version = "0.10.0", features = ["bindings-python"] }
-ferveo = { package = "ferveo-pre-release", version = "0.1.0-alpha.10", features = ["bindings-python"], git = "https://github.com/nucypher/ferveo.git", rev = "4939e79fd336a08547984d66dd0f7a256ab9dcf7" }
+ferveo = { package = "ferveo-pre-release", version = "0.1.0-alpha.10", features = ["bindings-python"], git = "https://github.com/nucypher/ferveo.git", rev = "c60ab3e28eef2dadf5502133472dbde44a25375a" }
 derive_more = { version = "0.99", default-features = false, features = ["from", "as_ref"] }
 
 [build-dependencies]

--- a/nucypher-core-python/src/lib.rs
+++ b/nucypher-core-python/src/lib.rs
@@ -7,7 +7,10 @@ extern crate alloc;
 
 use alloc::collections::{BTreeMap, BTreeSet};
 
-use ferveo::bindings_python::{Ciphertext, FerveoPublicKey};
+use ferveo::{
+    api::FerveoVariant,
+    bindings_python::{Ciphertext, FerveoPublicKey},
+};
 use pyo3::class::basic::CompareOp;
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
@@ -18,7 +21,6 @@ use umbral_pre::bindings_python::{
     VerifiedCapsuleFrag, VerifiedKeyFrag,
 };
 
-use nucypher_core::FerveoVariant;
 use nucypher_core::ProtocolObject;
 
 fn to_bytes<'a, T, U>(obj: &T) -> PyObject
@@ -763,8 +765,8 @@ impl ThresholdDecryptionRequest {
         context: Option<&Context>,
     ) -> PyResult<Self> {
         let ferveo_variant = match variant {
-            0 => FerveoVariant::SIMPLE,
-            1 => FerveoVariant::PRECOMPUTED,
+            0 => FerveoVariant::Simple,
+            1 => FerveoVariant::Precomputed,
             _ => {
                 return Err(PyValueError::new_err(
                     "Invalid ThresholdDecryptionRequest variant",
@@ -816,8 +818,8 @@ impl ThresholdDecryptionRequest {
     #[getter]
     pub fn variant(&self) -> u8 {
         match self.backend.variant {
-            FerveoVariant::SIMPLE => 0,
-            FerveoVariant::PRECOMPUTED => 1,
+            FerveoVariant::Simple => 0,
+            FerveoVariant::Precomputed => 1,
         }
     }
 

--- a/nucypher-core-wasm/Cargo.toml
+++ b/nucypher-core-wasm/Cargo.toml
@@ -20,7 +20,7 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 umbral-pre = { version = "0.10.0", features = ["bindings-wasm"] }
-ferveo = { package = "ferveo-pre-release", version = "0.1.0-alpha.10", features = ["bindings-wasm"], git = "https://github.com/nucypher/ferveo.git", rev = "4939e79fd336a08547984d66dd0f7a256ab9dcf7" }
+ferveo = { package = "ferveo-pre-release", version = "0.1.0-alpha.10", features = ["bindings-wasm"], git = "https://github.com/nucypher/ferveo.git", rev = "c60ab3e28eef2dadf5502133472dbde44a25375a" }
 nucypher-core = { path = "../nucypher-core" }
 wasm-bindgen = "0.2.86"
 js-sys = "0.3.63"

--- a/nucypher-core-wasm/Cargo.toml
+++ b/nucypher-core-wasm/Cargo.toml
@@ -20,7 +20,7 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 umbral-pre = { version = "0.10.0", features = ["bindings-wasm"] }
-ferveo = { package = "ferveo-pre-release", version = "0.1.0-alpha.10", features = ["bindings-wasm"], git = "https://github.com/nucypher/ferveo.git", rev = "90c73180f00f8a1122594881ea67f5a75a9fb0b1" }
+ferveo = { package = "ferveo-pre-release", version = "0.2.0", features = ["bindings-wasm"] }
 nucypher-core = { path = "../nucypher-core" }
 wasm-bindgen = "0.2.86"
 js-sys = "0.3.63"

--- a/nucypher-core-wasm/Cargo.toml
+++ b/nucypher-core-wasm/Cargo.toml
@@ -20,7 +20,7 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 umbral-pre = { version = "0.10.0", features = ["bindings-wasm"] }
-ferveo = { package = "ferveo-pre-release", version = "0.1.0-alpha.10", features = ["bindings-wasm"], git = "https://github.com/nucypher/ferveo.git", rev = "c60ab3e28eef2dadf5502133472dbde44a25375a" }
+ferveo = { package = "ferveo-pre-release", version = "0.1.0-alpha.10", features = ["bindings-wasm"], git = "https://github.com/nucypher/ferveo.git", rev = "90c73180f00f8a1122594881ea67f5a75a9fb0b1" }
 nucypher-core = { path = "../nucypher-core" }
 wasm-bindgen = "0.2.86"
 js-sys = "0.3.63"

--- a/nucypher-core-wasm/Cargo.toml
+++ b/nucypher-core-wasm/Cargo.toml
@@ -20,7 +20,7 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 umbral-pre = { version = "0.10.0", features = ["bindings-wasm"] }
-ferveo = { package = "ferveo-pre-release", version = "0.1.0-alpha.10", features = ["bindings-wasm"] }
+ferveo = { package = "ferveo-pre-release", version = "0.1.0-alpha.10", features = ["bindings-wasm"], git = "https://github.com/nucypher/ferveo.git", rev = "4939e79fd336a08547984d66dd0f7a256ab9dcf7" }
 nucypher-core = { path = "../nucypher-core" }
 wasm-bindgen = "0.2.86"
 js-sys = "0.3.63"

--- a/nucypher-core-wasm/src/lib.rs
+++ b/nucypher-core-wasm/src/lib.rs
@@ -12,7 +12,7 @@ use alloc::{
 };
 use core::fmt;
 
-use ferveo::bindings_wasm::Ciphertext;
+use ferveo::{api::FerveoVariant, bindings_wasm::Ciphertext};
 use js_sys::Error;
 use umbral_pre::bindings_wasm::{
     Capsule, PublicKey, RecoverableSignature, SecretKey, Signer, VerifiedCapsuleFrag,
@@ -22,7 +22,7 @@ use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 use wasm_bindgen::JsCast;
 use wasm_bindgen_derive::TryFromJsValue;
 
-use nucypher_core::{FerveoVariant, ProtocolObject};
+use nucypher_core::ProtocolObject;
 
 // Re-export certain types so they can be used from `nucypher-core` WASM bindings directly.
 pub use ferveo::bindings_wasm::{FerveoPublicKey, Keypair};
@@ -673,8 +673,8 @@ impl ThresholdDecryptionRequest {
         let typed_context = try_from_js_option::<Context>(context)?;
 
         let ferveo_variant = match variant {
-            0 => FerveoVariant::SIMPLE,
-            1 => FerveoVariant::PRECOMPUTED,
+            0 => FerveoVariant::Simple,
+            1 => FerveoVariant::Precomputed,
             _ => return Err(Error::new("Invalid variant")),
         };
 
@@ -695,8 +695,8 @@ impl ThresholdDecryptionRequest {
     #[wasm_bindgen(getter)]
     pub fn variant(&self) -> u8 {
         match self.0.variant {
-            FerveoVariant::SIMPLE => 0,
-            FerveoVariant::PRECOMPUTED => 1,
+            FerveoVariant::Simple => 0,
+            FerveoVariant::Precomputed => 1,
         }
     }
 

--- a/nucypher-core/Cargo.toml
+++ b/nucypher-core/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 umbral-pre = { version = "0.10.0", features = ["serde"] }
-ferveo = { package = "ferveo-pre-release", version = "0.1.0-alpha.10", git = "https://github.com/nucypher/ferveo.git", rev = "90c73180f00f8a1122594881ea67f5a75a9fb0b1" }
+ferveo = { package = "ferveo-pre-release", version = "0.2.0" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 generic-array = { version = "0.14", features = ["zeroize"] }
 sha3 = "0.10"

--- a/nucypher-core/Cargo.toml
+++ b/nucypher-core/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 umbral-pre = { version = "0.10.0", features = ["serde"] }
-ferveo = { package = "ferveo-pre-release", version = "0.1.0-alpha.10" }
+ferveo = { package = "ferveo-pre-release", version = "0.1.0-alpha.10", git = "https://github.com/nucypher/ferveo.git", rev = "4939e79fd336a08547984d66dd0f7a256ab9dcf7" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 generic-array = { version = "0.14", features = ["zeroize"] }
 sha3 = "0.10"

--- a/nucypher-core/Cargo.toml
+++ b/nucypher-core/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 umbral-pre = { version = "0.10.0", features = ["serde"] }
-ferveo = { package = "ferveo-pre-release", version = "0.1.0-alpha.10", git = "https://github.com/nucypher/ferveo.git", rev = "4939e79fd336a08547984d66dd0f7a256ab9dcf7" }
+ferveo = { package = "ferveo-pre-release", version = "0.1.0-alpha.10", git = "https://github.com/nucypher/ferveo.git", rev = "c60ab3e28eef2dadf5502133472dbde44a25375a" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 generic-array = { version = "0.14", features = ["zeroize"] }
 sha3 = "0.10"

--- a/nucypher-core/Cargo.toml
+++ b/nucypher-core/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 umbral-pre = { version = "0.10.0", features = ["serde"] }
-ferveo = { package = "ferveo-pre-release", version = "0.1.0-alpha.10", git = "https://github.com/nucypher/ferveo.git", rev = "c60ab3e28eef2dadf5502133472dbde44a25375a" }
+ferveo = { package = "ferveo-pre-release", version = "0.1.0-alpha.10", git = "https://github.com/nucypher/ferveo.git", rev = "90c73180f00f8a1122594881ea67f5a75a9fb0b1" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 generic-array = { version = "0.14", features = ["zeroize"] }
 sha3 = "0.10"

--- a/nucypher-core/src/dkg.rs
+++ b/nucypher-core/src/dkg.rs
@@ -1,7 +1,7 @@
 use alloc::boxed::Box;
 use alloc::string::String;
 use core::fmt;
-use ferveo::api::Ciphertext;
+use ferveo::api::{Ciphertext, FerveoVariant};
 use generic_array::typenum::Unsigned;
 
 use serde::{Deserialize, Serialize};
@@ -98,15 +98,6 @@ fn decrypt_with_shared_secret(
         .decrypt(nonce, encrypted_data)
         .map_err(|_err| DecryptionError::AuthenticationFailed)?;
     Ok(plaintext.into_boxed_slice())
-}
-
-/// The ferveo variant to use for the decryption share derivation.
-#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Copy, Clone)]
-pub enum FerveoVariant {
-    /// The simple variant requires m of n shares to decrypt
-    SIMPLE,
-    /// The precomputed variant requires n of n shares to decrypt
-    PRECOMPUTED,
 }
 
 /// Module for session key objects.
@@ -601,11 +592,11 @@ impl<'a> ProtocolObject<'a> for EncryptedThresholdDecryptionResponse {}
 
 #[cfg(test)]
 mod tests {
-    use ferveo::api::{encrypt as ferveo_encrypt, DkgPublicKey, SecretBox};
+    use ferveo::api::{encrypt as ferveo_encrypt, DkgPublicKey, FerveoVariant, SecretBox};
 
     use crate::{
         Conditions, Context, EncryptedThresholdDecryptionRequest,
-        EncryptedThresholdDecryptionResponse, FerveoVariant, ProtocolObject, SessionSecretFactory,
+        EncryptedThresholdDecryptionResponse, ProtocolObject, SessionSecretFactory,
         SessionStaticKey, ThresholdDecryptionRequest, ThresholdDecryptionResponse,
     };
 
@@ -742,7 +733,7 @@ mod tests {
             &ciphertext,
             Some(&Conditions::new("abcd")),
             Some(&Context::new("efgh")),
-            FerveoVariant::SIMPLE,
+            FerveoVariant::Simple,
         );
 
         // requester encrypts request to send to service

--- a/nucypher-core/src/lib.rs
+++ b/nucypher-core/src/lib.rs
@@ -30,7 +30,7 @@ pub use conditions::{Conditions, Context};
 pub use dkg::{
     session::{SessionSecretFactory, SessionSharedSecret, SessionStaticKey, SessionStaticSecret},
     DecryptionError, EncryptedThresholdDecryptionRequest, EncryptedThresholdDecryptionResponse,
-    EncryptionError, FerveoVariant, ThresholdDecryptionRequest, ThresholdDecryptionResponse,
+    EncryptionError, ThresholdDecryptionRequest, ThresholdDecryptionResponse,
 };
 pub use fleet_state::FleetStateChecksum;
 pub use hrac::HRAC;


### PR DESCRIPTION
**Type of PR:**
- Feature

**Required reviews:** 
- 1

**What this does:**
- Implement changes required for compatibility with an upcoming Ferveo release

**Issues fixed/closed:**
- Refers to: https://github.com/nucypher/ferveo/pull/136
- Refers to: https://github.com/nucypher/ferveo/pull/134
- Refers to: https://github.com/nucypher/ferveo/pull/137
- Fixes: #68 

**Why it's needed:**
- Need to keep track of upcoming changes in Ferveo and test them before the release

**Notes for reviewers:**
- Requires MINOR version bump because of a breaking change in #136
- Downstream changes:
  - https://github.com/nucypher/nucypher/pull/3171