### PR TITLE
Conditions should not be optional for CBD types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.13.0] - Unreleased
+
+### Changed
+
+- `Conditions` should not be optional as it pertains to `AuthenticatedData` and `AccessControlPolicy` types since conditions-based decryption (CBD) requires conditions. ([#80])
+
+[#80]: https://github.com/nucypher/nucypher-core/pull/78
+
+
 ## [0.12.0] - 2023-08-28
 
 ### Changed
 
-- Modified `ThresholdDecryptionResponse`  to use `CiphertextHeader` and `AccessControlPolicy` to utilize encapsulation now provided by `ferveo`. ([#74])
+- Modified `ThresholdDecryptionRequest`  to use `CiphertextHeader` and `AccessControlPolicy` to utilize encapsulation now provided by `ferveo`. ([#74])
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,7 +869,7 @@ checksum = "94c7128ba23c81f6471141b90f17654f89ef44a56e14b8a4dd0fddfccd655277"
 
 [[package]]
 name = "nucypher-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chacha20poly1305",
  "ferveo-pre-release",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "nucypher-core-python"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "derive_more",
  "ferveo-pre-release",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "nucypher-core-wasm"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "console_error_panic_hook",
  "derive_more",

--- a/nucypher-core-python/nucypher_core/__init__.pyi
+++ b/nucypher-core-python/nucypher_core/__init__.pyi
@@ -434,12 +434,12 @@ class MetadataResponse:
 @final
 class AuthenticatedData:
 
-    def __init__(self, public_key: DkgPublicKey, conditions: Optional[Conditions]):
+    def __init__(self, public_key: DkgPublicKey, conditions: Conditions):
         ...
 
     public_key: DkgPublicKey
 
-    conditions: Optional[Conditions]
+    conditions: Conditions
 
     def aad(self) -> bytes:
         ...
@@ -452,7 +452,7 @@ class AuthenticatedData:
         ...
 
 
-def encrypt_for_dkg(data: bytes, public_key: DkgPublicKey, conditions: Optional[Conditions]) -> Tuple[Ciphertext, AuthenticatedData]:
+def encrypt_for_dkg(data: bytes, public_key: DkgPublicKey, conditions: Conditions) -> Tuple[Ciphertext, AuthenticatedData]:
     ...
 
 
@@ -464,7 +464,7 @@ class AccessControlPolicy:
 
     public_key: DkgPublicKey
 
-    conditions: Optional[Conditions]
+    conditions: Conditions
 
     authorization: bytes
 

--- a/nucypher-core-wasm/src/lib.rs
+++ b/nucypher-core-wasm/src/lib.rs
@@ -684,12 +684,12 @@ impl AuthenticatedData {
 
     #[wasm_bindgen(getter, js_name = publicKey)]
     pub fn public_key(&self) -> DkgPublicKey {
-        DkgPublicKey::from(self.0.public_key)
+        self.0.public_key.into()
     }
 
     #[wasm_bindgen(getter)]
     pub fn conditions(&self) -> Conditions {
-        Conditions::from(self.0.conditions.clone())
+        self.0.conditions.clone().into()
     }
 }
 
@@ -742,7 +742,7 @@ impl AccessControlPolicy {
 
     #[wasm_bindgen(getter, js_name = publicKey)]
     pub fn public_key(&self) -> DkgPublicKey {
-        DkgPublicKey::from(self.0.auth_data.public_key)
+        self.0.auth_data.public_key.into()
     }
 
     #[wasm_bindgen(getter)]
@@ -752,7 +752,7 @@ impl AccessControlPolicy {
 
     #[wasm_bindgen(getter)]
     pub fn conditions(&self) -> Conditions {
-        Conditions::from(self.0.auth_data.conditions.clone())
+        self.0.auth_data.conditions.clone().into()
     }
 }
 

--- a/nucypher-core/src/dkg.rs
+++ b/nucypher-core/src/dkg.rs
@@ -730,7 +730,7 @@ mod tests {
             let aad = "my-add".as_bytes();
             let ciphertext = ferveo_encrypt(SecretBox::new(message), aad, &dkg_pk).unwrap();
 
-            let auth_data = AuthenticatedData::new(&dkg_pk, Some(&Conditions::new("abcd")));
+            let auth_data = AuthenticatedData::new(&dkg_pk, &Conditions::new("abcd"));
 
             let authorization = b"self_authorization";
             let acp = AccessControlPolicy::new(&auth_data, authorization);

--- a/nucypher-core/src/threshold_message_kit.rs
+++ b/nucypher-core/src/threshold_message_kit.rs
@@ -88,7 +88,7 @@ mod tests {
 
         let authorization = b"we_dont_need_no_stinking_badges";
         let acp = AccessControlPolicy::new(
-            &AuthenticatedData::new(&dkg_pk, Some(&Conditions::new("abcd"))),
+            &AuthenticatedData::new(&dkg_pk, &Conditions::new("abcd")),
             authorization,
         );
 


### PR DESCRIPTION
…ata and AccessControlPolicy.

**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
> High-level idea of the changes introduced in this PR. 
> List relevant API changes (if any), as well as related PRs and issues.

**Issues fixed/closed:**
Related to #76 .

**Why it's needed:**
Conditions should not be optional for CBD - it's kind of the whole point.

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?

Already ran parts of the test suite locally with `nucypher` to test python bindings. There are no downstream changes necessary for `nucypher` other than an updated `nucypher-core` dependency, because conditions were not optional for CBD functionality in `nucypher` anyway.