### PR TITLE
chore(ci): use binary wasm-pack distribution

### DIFF
--- a/.github/workflows/nucypher-core.yml
+++ b/.github/workflows/nucypher-core.yml
@@ -20,8 +20,6 @@ defaults:
 env:
   CARGO_INCREMENTAL: 0
   RUSTFLAGS: "-Dwarnings"
-  WASM_PACK_VERSION: 0.12.0
-  WASM_OPT_VERSION: 0.114.1
 
 jobs:
 
@@ -52,8 +50,8 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.71 # MSRV for wasm-opt & wasm-pack
-#          - stable
+          - 1.67 # MSRV
+          - stable
         target:
           - wasm32-unknown-unknown
 
@@ -65,7 +63,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo install wasm-opt@${{ env.WASM_OPT_VERSION }} wasm-pack@${{ env.WASM_PACK_VERSION }}
+      - run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - run: cd ../nucypher-core-wasm && wasm-pack test --node
 
   yarn-test:
@@ -85,7 +83,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo install wasm-opt@${{ env.WASM_OPT_VERSION }} wasm-pack@${{ env.WASM_PACK_VERSION }}
+      - run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - run: make
         working-directory: nucypher-core-wasm
       - uses: borales/actions-yarn@v3.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,7 +869,7 @@ checksum = "94c7128ba23c81f6471141b90f17654f89ef44a56e14b8a4dd0fddfccd655277"
 
 [[package]]
 name = "nucypher-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chacha20poly1305",
  "ferveo-pre-release",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "nucypher-core-python"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "derive_more",
  "ferveo-pre-release",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "nucypher-core-wasm"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "console_error_panic_hook",
  "derive_more",


### PR DESCRIPTION
**Type of PR:**
- Other

**Required reviews:** 
- 1

**What this does:**
- Installs `wasm-pack` from a precompiled binary
- Fixes a listing issue on Rust `stable`
- Copies changes from https://github.com/nucypher/ferveo/pull/159

**Why it's needed:**
- Some child dependencies in `wasm-pack` an `wasm-opt` get updated from time to time and that causes MSRV float
- With these changes, we should be able to avoid that in the future, and hence avoid CI breaking from time to time