### PR TITLE
Fix Python typing stubs

### DIFF
--- a/nucypher-core-python/nucypher_core/__init__.pyi
+++ b/nucypher-core-python/nucypher_core/__init__.pyi
@@ -488,7 +488,7 @@ class ThresholdMessageKit:
 
     ciphertext_header: CiphertextHeader
 
-    def decrypt_with_shared_secret(self, shared_secret: SharedSecret):
+    def decrypt_with_shared_secret(self, shared_secret: SharedSecret) -> bytes:
         ...
 
     @staticmethod

--- a/nucypher-core-python/nucypher_core/ferveo.pyi
+++ b/nucypher-core-python/nucypher_core/ferveo.pyi
@@ -224,7 +224,7 @@ def encrypt(message: bytes, aad: bytes, dkg_public_key: DkgPublicKey) -> Ciphert
 
 def combine_decryption_shares_simple(
         decryption_shares: Sequence[DecryptionShareSimple],
-) -> bytes:
+) -> SharedSecret:
     ...
 
 


### PR DESCRIPTION
**Type of PR:**
- Bugfix

**Required reviews:** 
- 1

**What this does:**
Fixes some incorrect Python typing stubs:
- `ThresholdMessageKit.decrypt_with_shared_secret()` - added a missing `bytes` return type
- `combine_decryption_shares_simple()` - replaced the incorrect `bytes` return type with `SharedSecret`