### PR TITLE
Release v0.14.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.13.0
+current_version = 0.14.0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Fixed Python typings for `ThresholdMessageKit.decrypt_with_shared_secret()` and `combine_decryption_shares_simple()` ([#84])
 - Inlined WASM modules to simplify packaging for WASM users ([#83])
 
 ### Added
 
 - Support for Python 3.11-3.12  ([#87])
 
+### Fixed
+
+- Fixed Python typings for `ThresholdMessageKit.decrypt_with_shared_secret()` and `combine_decryption_shares_simple()` ([#84])
+
+
 [#84]: https://github.com/nucypher/nucypher-core/pull/84
+[#83]: https://github.com/nucypher/nucypher-core/pull/83
 [#87]: https://github.com/nucypher/nucypher-core/pull/87
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.14.0] - 2024-01-12
+
+### Changed
+
+- Fixed Python typings for `ThresholdMessageKit.decrypt_with_shared_secret()` and `combine_decryption_shares_simple()` ([#84])
+- Inlined WASM modules to simplify packaging for WASM users ([#83])
+
+### Added
+
+- Support for Python 3.11-3.12  ([#87])
+
+[#84]: https://github.com/nucypher/nucypher-core/pull/84
+[#87]: https://github.com/nucypher/nucypher-core/pull/87
+
+
 ## [0.13.0] - 2023-09-06
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,7 +869,7 @@ checksum = "94c7128ba23c81f6471141b90f17654f89ef44a56e14b8a4dd0fddfccd655277"
 
 [[package]]
 name = "nucypher-core"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chacha20poly1305",
  "ferveo-pre-release",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "nucypher-core-python"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "derive_more",
  "ferveo-pre-release",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "nucypher-core-wasm"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "console_error_panic_hook",
  "derive_more",

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -38,12 +38,12 @@ Gitub Actions are configured to take care of this automatically.
 
 ## NPM package
 
-In `nucypher-core-wasm` dir:
+In `nucypher-core-wasm-bundler` directory:
 
-- `rm -rf pkg`.
-- `make`.
-- `wasm-pack login`.
-- `cd pkg`.
-- `npm publish --access=public`.
+```bash
+npm install
+npm build
+npm publish --access=public
+```
 
 See see https://rustwasm.github.io/docs/wasm-pack/tutorials/npm-browser-packages/packaging-and-publishing.html for more info on publishing.

--- a/nucypher-core-python/Cargo.toml
+++ b/nucypher-core-python/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nucypher-core-python"
 authors = ["Bogdan Opanchuk <bogdan@opanchuk.net>"]
-version = "0.13.0"
+version = "0.14.0"
 edition = "2018"
 
 [lib]

--- a/nucypher-core-python/setup.py
+++ b/nucypher-core-python/setup.py
@@ -10,7 +10,7 @@ setup(
     description="Protocol structures of Nucypher network",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    version="0.13.0",
+    version="0.14.0",
     author="Bogdan Opanchuk",
     author_email="bogdan@opanchuk.net",
     url="https://github.com/nucypher/nucypher-core/tree/main/nucypher-core-python",

--- a/nucypher-core-wasm-bundler/package-lock.json
+++ b/nucypher-core-wasm-bundler/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nucypher/nucypher-core",
-  "version": "0.13.0-alpha.0",
+  "version": "0.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nucypher/nucypher-core",
-      "version": "0.13.0-alpha.0",
+      "version": "0.14.1",
       "license": "GPL-3.0-only",
       "devDependencies": {
         "@rollup/plugin-typescript": "^11.1.3",

--- a/nucypher-core-wasm-bundler/package.json
+++ b/nucypher-core-wasm-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nucypher/nucypher-core",
-  "version": "0.13.0-alpha.1",
+  "version": "0.14.0",
   "license": "GPL-3.0-only",
   "sideEffects": false,
   "type": "module",

--- a/nucypher-core-wasm-bundler/package.json
+++ b/nucypher-core-wasm-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nucypher/nucypher-core",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "license": "GPL-3.0-only",
   "sideEffects": false,
   "type": "module",

--- a/nucypher-core-wasm/Cargo.toml
+++ b/nucypher-core-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nucypher-core-wasm"
-version = "0.13.0"
+version = "0.14.0"
 authors = [
     "Bogdan Opanchuk <bogdan@opanchuk.net>",
     "Piotr Roslaniec <p.roslaniec@gmail.com>"

--- a/nucypher-core-wasm/package.template.json
+++ b/nucypher-core-wasm/package.template.json
@@ -5,7 +5,7 @@
     "Bogdan Opanchuk <bogdan@opanchuk.net>"
   ],
   "description": "NuCypher network core data structures",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "license": "GPL-3.0-only",
   "repository": {
     "type": "git",

--- a/nucypher-core/Cargo.toml
+++ b/nucypher-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nucypher-core"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Bogdan Opanchuk <bogdan@opanchuk.net>"]
 edition = "2021"
 license = "GPL-3.0-only"


### PR DESCRIPTION

**Type of PR:**
- Other

**Required reviews:** 
- 1

**What this does:**
- Documents and releases prior changes
- Removing publishing docs for old WASM packaging

**Why it's needed:**
- Releasing a new npm package will help with some packaging issues in `taco-web`

**Notes for reviewers:**
- Release Python package after merging: https://github.com/nucypher/rust-umbral/actions/workflows/wheels.yml
- Also squeezing in a `@nucypher/nucypher-core:0.14.1`, because I accidentally released WASM bundled with the old method instead of the new inlined method