### PR TITLE
Canonical AA v0.7 Support

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.15.1-dev.3
+current_version = 0.15.1-dev.4
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?

--- a/.github/workflows/nucypher-core.yml
+++ b/.github/workflows/nucypher-core.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [22, 24]
         rust:
           - stable
         target:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2382,7 +2382,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nucypher-core"
-version = "0.15.1-dev.3"
+version = "0.15.1-dev.4"
 dependencies = [
  "ark-std",
  "chacha20poly1305",
@@ -2408,7 +2408,7 @@ dependencies = [
 
 [[package]]
 name = "nucypher-core-python"
-version = "0.15.1-dev.3"
+version = "0.15.1-dev.4"
 dependencies = [
  "derive_more 0.99.20",
  "ferveo-nucypher",
@@ -2423,7 +2423,7 @@ dependencies = [
 
 [[package]]
 name = "nucypher-core-wasm"
-version = "0.15.1-dev.3"
+version = "0.15.1-dev.4"
 dependencies = [
  "ark-std",
  "console_error_panic_hook",

--- a/nucypher-core-python/Cargo.toml
+++ b/nucypher-core-python/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nucypher-core-python"
 authors = ["Bogdan Opanchuk <bogdan@opanchuk.net>"]
-version = "0.15.1-dev.3"
+version = "0.15.1-dev.4"
 edition = "2018"
 
 [lib]

--- a/nucypher-core-python/nucypher_core/__init__.py
+++ b/nucypher-core-python/nucypher_core/__init__.py
@@ -49,5 +49,6 @@ class SignatureRequestType:
 # Constants for AA versions
 class AAVersion:
     """Constants for AA (Account Abstraction) versions."""
+    V07 = "0.7.0"
     V08 = "0.8.0"
     MDT = "mdt"

--- a/nucypher-core-python/nucypher_core/__init__.pyi
+++ b/nucypher-core-python/nucypher_core/__init__.pyi
@@ -900,8 +900,8 @@ class PackedUserOperation:
         """Convert to EIP-712 struct format."""
         ...
 
-    def to_v07_encoding(self, chain_id: int) -> bytes:
-        """Convert to v0.7.0 encoding format."""
+    def to_v07_hash(self, chain_id: int) -> bytes:
+        """Convert to AA v0.7.0 hash format."""
         ...
     
     @property

--- a/nucypher-core-python/nucypher_core/__init__.pyi
+++ b/nucypher-core-python/nucypher_core/__init__.pyi
@@ -41,7 +41,7 @@ class Address:
     def __hash__(self) -> int:
         ...
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other, /) -> bool:
         ...
 
 

--- a/nucypher-core-python/nucypher_core/__init__.pyi
+++ b/nucypher-core-python/nucypher_core/__init__.pyi
@@ -712,6 +712,7 @@ class SignatureRequestType:
 
 @final
 class AAVersion:
+    V07: str = "0.7.0"
     V08: str = "0.8.0"
     MDT: str = "mdt"
 
@@ -897,6 +898,10 @@ class PackedUserOperation:
     
     def to_eip712_struct(self, aa_version: str, chain_id: int) -> Dict[str, Any]:
         """Convert to EIP-712 struct format."""
+        ...
+
+    def to_v07_encoding(self, chain_id: int) -> bytes:
+        """Convert to v0.7.0 encoding format."""
         ...
     
     @property

--- a/nucypher-core-python/nucypher_core/ferveo.pyi
+++ b/nucypher-core-python/nucypher_core/ferveo.pyi
@@ -41,7 +41,7 @@ class FerveoPublicKey:
     def serialized_size() -> int:
         ...
 
-    def __eq__(self, other: object) -> bool:
+    def __eq__(self, other: object, /) -> bool:
         ...
 
 
@@ -243,7 +243,7 @@ class FerveoVariant:
     Simple: FerveoVariant
     Precomputed: FerveoVariant
 
-    def __eq__(self, other: object) -> bool:
+    def __eq__(self, other: object, /) -> bool:
         ...
 
     def __hash__(self) -> int:

--- a/nucypher-core-python/setup.py
+++ b/nucypher-core-python/setup.py
@@ -10,7 +10,7 @@ setup(
     description="Protocol structures of Nucypher network",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    version="0.15.1-dev.3",
+    version="0.15.1-dev.4",
     author="Bogdan Opanchuk",
     author_email="bogdan@opanchuk.net",
     url="https://github.com/nucypher/nucypher-core/tree/main/nucypher-core-python",

--- a/nucypher-core-python/src/lib.rs
+++ b/nucypher-core-python/src/lib.rs
@@ -1916,7 +1916,10 @@ impl PackedUserOperation {
     pub fn to_eip712_struct(&self, aa_version: &str, chain_id: u64) -> PyResult<PyObject> {
         let core_aa_version = nucypher_core::AAVersion::from_str(aa_version)
             .map_err(|err| PyValueError::new_err(err.to_string()))?;
-        let eip712_struct = self.backend.to_eip712_struct(&core_aa_version, chain_id);
+        let eip712_struct = self
+            .backend
+            .to_eip712_struct(&core_aa_version, chain_id)
+            .map_err(|err| PyValueError::new_err(err.to_string()))?;
 
         Python::with_gil(|py| json_to_pyobject(py, &serde_json::Value::Object(eip712_struct)))
     }
@@ -1937,6 +1940,11 @@ impl PackedUserOperation {
         let domain = self.backend.get_domain(&core_aa_version, chain_id);
 
         Python::with_gil(|py| json_to_pyobject(py, &serde_json::Value::Object(domain)))
+    }
+
+    pub fn to_v07_encoding(&self, chain_id: u64) -> PyObject {
+        let encoding = self.backend.to_v07_encoding(chain_id);
+        Python::with_gil(|py| PyBytes::new(py, &encoding).into())
     }
 }
 

--- a/nucypher-core-python/src/lib.rs
+++ b/nucypher-core-python/src/lib.rs
@@ -1942,9 +1942,9 @@ impl PackedUserOperation {
         Python::with_gil(|py| json_to_pyobject(py, &serde_json::Value::Object(domain)))
     }
 
-    pub fn to_v07_encoding(&self, chain_id: u64) -> PyObject {
-        let encoding = self.backend.to_v07_encoding(chain_id);
-        Python::with_gil(|py| PyBytes::new(py, &encoding).into())
+    pub fn to_v07_hash(&self, chain_id: u64) -> PyObject {
+        let v07_hash = self.backend.to_v07_hash(chain_id);
+        Python::with_gil(|py| PyBytes::new(py, &v07_hash).into())
     }
 }
 

--- a/nucypher-core-wasm-bundler/package-lock.json
+++ b/nucypher-core-wasm-bundler/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nucypher/nucypher-core",
-  "version": "0.15.1-dev.3",
+  "version": "0.15.1-dev.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nucypher/nucypher-core",
-      "version": "0.15.1-dev.3",
+      "version": "0.15.1-dev.4",
       "license": "GPL-3.0-only",
       "devDependencies": {
         "@rollup/plugin-typescript": "^11.1.3",

--- a/nucypher-core-wasm-bundler/package.json
+++ b/nucypher-core-wasm-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nucypher/nucypher-core",
-  "version": "0.15.1-dev.3",
+  "version": "0.15.1-dev.4",
   "license": "GPL-3.0-only",
   "sideEffects": false,
   "type": "module",

--- a/nucypher-core-wasm/Cargo.toml
+++ b/nucypher-core-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nucypher-core-wasm"
-version = "0.15.1-dev.3"
+version = "0.15.1-dev.4"
 authors = [
     "Bogdan Opanchuk <bogdan@opanchuk.net>",
     "Piotr Roslaniec <p.roslaniec@gmail.com>"

--- a/nucypher-core-wasm/package.template.json
+++ b/nucypher-core-wasm/package.template.json
@@ -5,7 +5,7 @@
     "Bogdan Opanchuk <bogdan@opanchuk.net>"
   ],
   "description": "NuCypher network core data structures",
-  "version": "0.15.1-dev.3",
+  "version": "0.15.1-dev.4",
   "license": "GPL-3.0-only",
   "repository": {
     "type": "git",

--- a/nucypher-core/Cargo.toml
+++ b/nucypher-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nucypher-core"
-version = "0.15.1-dev.3"
+version = "0.15.1-dev.4"
 authors = ["Bogdan Opanchuk <bogdan@opanchuk.net>"]
 edition = "2021"
 license = "GPL-3.0-only"

--- a/nucypher-core/src/reencryption.rs
+++ b/nucypher-core/src/reencryption.rs
@@ -125,6 +125,7 @@ impl ReencryptionResponse {
     }
 
     /// Verifies the reencryption response and returns the contained kfrags on success.
+    #[allow(clippy::result_large_err)]
     pub fn verify(
         self,
         capsules: &[Capsule],

--- a/nucypher-core/src/signature_request.rs
+++ b/nucypher-core/src/signature_request.rs
@@ -588,10 +588,9 @@ impl PackedUserOperation {
         Ok(result)
     }
 
-    /// Converts to V07 encoded data format
-    pub fn to_v07_encoding(&self, chain_id: u64) -> Vec<u8> {
+    /// Converts PackedUserOperation fields to ABI encoded data format
+    pub fn to_v07_abi_encoded_fields(&self) -> Vec<u8> {
         // ABI encode PackedUserOperation values for V07 entryPoint
-        // Hash the dynamic byte fields
         let init_code_hash = Keccak256::new().chain(self.init_code.as_ref()).finalize();
         let call_data_hash = Keccak256::new().chain(self.call_data.as_ref()).finalize();
         let paymaster_and_data_hash = Keccak256::new()
@@ -610,14 +609,16 @@ impl PackedUserOperation {
             Token::FixedBytes(self.gas_fees.as_ref().to_vec()),
             Token::FixedBytes(paymaster_and_data_hash.to_vec()),
         ];
+        encode(&tokens)
+    }
 
-        // final encoding for V07 is keccak256(abi.encode(...))
-        let encoded_packed_user_op = encode(&tokens);
+    /// Converts to AA v07 encoded data format
+    pub fn to_v07_hash(&self, chain_id: u64) -> Vec<u8> {
         let hashed_packed_user_op = Keccak256::new()
-            .chain(encoded_packed_user_op)
+            .chain(self.to_v07_abi_encoded_fields())
             .finalize()
             .to_vec();
-        let final_tokens = vec![
+        let tokens = vec![
             Token::FixedBytes(hashed_packed_user_op),
             Token::Address(ethers::types::H160::from_slice(
                 Address::from_str(ENTRYPOINT_V07)
@@ -626,10 +627,7 @@ impl PackedUserOperation {
             )),
             Token::Uint(ethers::types::U256::from(chain_id)),
         ];
-        Keccak256::new()
-            .chain(encode(&final_tokens))
-            .finalize()
-            .to_vec()
+        Keccak256::new().chain(encode(&tokens)).finalize().to_vec()
     }
 }
 
@@ -1715,7 +1713,7 @@ mod tests {
     }
 
     #[test]
-    fn test_packed_user_operation_to_v07_encoding() {
+    fn test_packed_user_operation_to_v07_abi_encoded_fields() {
         let sender = Address::from_str("0x1234567890123456789012345678901234567890").unwrap();
         let packed_user_op = PackedUserOperation::new(
             sender,
@@ -1728,25 +1726,92 @@ mod tests {
             b"paymaster_and_data",
         );
 
-        let encoded_data = packed_user_op.to_v07_encoding(137);
+        let encoded_user_op = packed_user_op.to_v07_abi_encoded_fields();
+
         // The encoded data should be the ABI encoding of the PackedUserOperation struct with the correct fields
         let decoded = ethers::abi::decode(
             &[
-                ethers::abi::ParamType::FixedBytes(32), // keccak256(abi.encode(packedUserOp))
-                ethers::abi::ParamType::Address,        // v07 entrypoint contract
-                ethers::abi::ParamType::Uint(256),      // chainId
+                ethers::abi::ParamType::Address,
+                ethers::abi::ParamType::Uint(256),
+                ethers::abi::ParamType::FixedBytes(32),
+                ethers::abi::ParamType::FixedBytes(32),
+                ethers::abi::ParamType::FixedBytes(32),
+                ethers::abi::ParamType::Uint(256),
+                ethers::abi::ParamType::FixedBytes(32),
+                ethers::abi::ParamType::FixedBytes(32),
             ],
-            &encoded_data,
+            &encoded_user_op,
         )
         .unwrap();
         assert_eq!(
-            decoded[1].clone().into_address().unwrap(),
-            ethers::types::H160::from_slice(Address::from_str(ENTRYPOINT_V07).unwrap().as_ref())
+            decoded[0].clone().into_address().unwrap(),
+            ethers::types::H160::from_slice(packed_user_op.sender.as_ref())
         );
         assert_eq!(
-            decoded[2].clone().into_uint().unwrap(),
-            ethers::types::U256::from(137)
+            decoded[1].clone().into_uint().unwrap(),
+            ethers::types::U256::from_big_endian(&packed_user_op.nonce.to_be_bytes(),)
         );
+        assert_eq!(
+            decoded[2].clone().into_fixed_bytes().unwrap(),
+            Keccak256::digest(&packed_user_op.init_code).as_slice()
+        );
+        assert_eq!(
+            decoded[3].clone().into_fixed_bytes().unwrap(),
+            Keccak256::digest(&packed_user_op.call_data).as_slice()
+        );
+        let mut expected_account_gas_limits = packed_user_op.account_gas_limits.to_vec();
+        expected_account_gas_limits.resize(32, 0); // pad to 32 bytes
+        assert_eq!(
+            decoded[4].clone().into_fixed_bytes().unwrap(),
+            expected_account_gas_limits
+        );
+        assert_eq!(
+            decoded[5].clone().into_uint().unwrap(),
+            ethers::types::U256::from(50000)
+        );
+        let mut expected_gas_fees = packed_user_op.gas_fees.to_vec();
+        expected_gas_fees.resize(32, 0); // pad to 32 bytes
+        assert_eq!(
+            decoded[6].clone().into_fixed_bytes().unwrap(),
+            expected_gas_fees
+        );
+        assert_eq!(
+            decoded[7].clone().into_fixed_bytes().unwrap(),
+            Keccak256::digest(&packed_user_op.paymaster_and_data).as_slice()
+        );
+    }
+
+    #[test]
+    fn test_packed_user_operation_to_v07_hash() {
+        let sender = Address::from_str("0x1234567890123456789012345678901234567890").unwrap();
+        let packed_user_op = PackedUserOperation::new(
+            sender,
+            Uint256::from(42),
+            b"init_code",
+            b"call_data",
+            b"account_gas_limits",
+            50000,
+            b"gas_fees",
+            b"paymaster_and_data",
+        );
+
+        let chain_id = 137;
+
+        let encoded_user_op = packed_user_op.to_v07_abi_encoded_fields();
+        let v07_encoding = packed_user_op.to_v07_hash(chain_id);
+
+        let hashed_encoded_user_op = Keccak256::digest(&encoded_user_op);
+
+        // The v07 encoding should be the keccak256 hash of the ABI encoding, entry point address, and chain id
+        let overall_tokens = vec![
+            Token::FixedBytes(hashed_encoded_user_op.as_slice().to_vec()),
+            Token::Address(ethers::types::H160::from_slice(
+                Address::from_str(ENTRYPOINT_V07).unwrap().as_ref(),
+            )),
+            Token::Uint(ethers::types::U256::from(chain_id)),
+        ];
+        let expected_v07_encoding = Keccak256::digest(&encode(&overall_tokens));
+        assert_eq!(expected_v07_encoding.as_slice(), v07_encoding.as_slice());
     }
 
     #[test]

--- a/nucypher-core/src/signature_request.rs
+++ b/nucypher-core/src/signature_request.rs
@@ -5,8 +5,10 @@ use alloc::{format, vec};
 use core::fmt;
 use core::str::FromStr;
 
+use ethers::abi::{encode, Token};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
+use sha3::{digest::Update, Digest, Keccak256};
 use umbral_pre::serde_bytes;
 
 use crate::address::Address;
@@ -498,7 +500,13 @@ impl PackedUserOperation {
         &self,
         aa_version: &AAVersion,
         chain_id: u64,
-    ) -> serde_json::Map<String, JsonValue> {
+    ) -> Result<serde_json::Map<String, JsonValue>, String> {
+        if *aa_version == AAVersion::V07 {
+            return Err(
+                "Not supported for AA v0.7.0 since it does not use EIP-712 signatures".into(),
+            );
+        }
+
         let mut result = serde_json::Map::new();
 
         // Create types
@@ -577,7 +585,51 @@ impl PackedUserOperation {
             JsonValue::Object(self.to_eip712_message(aa_version)),
         );
 
-        result
+        Ok(result)
+    }
+
+    /// Converts to V07 encoded data format
+    pub fn to_v07_encoding(&self, chain_id: u64) -> Vec<u8> {
+        // ABI encode PackedUserOperation values for V07 entryPoint
+        // Hash the dynamic byte fields
+        let init_code_hash = Keccak256::new().chain(self.init_code.as_ref()).finalize();
+        let call_data_hash = Keccak256::new().chain(self.call_data.as_ref()).finalize();
+        let paymaster_and_data_hash = Keccak256::new()
+            .chain(self.paymaster_and_data.as_ref())
+            .finalize();
+
+        let tokens = vec![
+            Token::Address(ethers::types::H160::from_slice(self.sender.as_ref())),
+            Token::Uint(ethers::types::U256::from_big_endian(
+                &self.nonce.to_be_bytes(),
+            )),
+            Token::FixedBytes(init_code_hash.to_vec()),
+            Token::FixedBytes(call_data_hash.to_vec()),
+            Token::FixedBytes(self.account_gas_limits.as_ref().to_vec()),
+            Token::Uint(ethers::types::U256::from(self.pre_verification_gas)),
+            Token::FixedBytes(self.gas_fees.as_ref().to_vec()),
+            Token::FixedBytes(paymaster_and_data_hash.to_vec()),
+        ];
+
+        // final encoding for V07 is keccak256(abi.encode(...))
+        let encoded_packed_user_op = encode(&tokens);
+        let hashed_packed_user_op = Keccak256::new()
+            .chain(encoded_packed_user_op)
+            .finalize()
+            .to_vec();
+        let final_tokens = vec![
+            Token::FixedBytes(hashed_packed_user_op),
+            Token::Address(ethers::types::H160::from_slice(
+                Address::from_str(ENTRYPOINT_V07)
+                    .expect("Invalid entry point address")
+                    .as_ref(),
+            )),
+            Token::Uint(ethers::types::U256::from(chain_id)),
+        ];
+        Keccak256::new()
+            .chain(encode(&final_tokens))
+            .finalize()
+            .to_vec()
     }
 }
 
@@ -1261,6 +1313,35 @@ mod tests {
         let deserialized_v08 = UserOperationSignatureRequest::from_bytes(&bytes).unwrap();
         assert_eq!(deserialized_v08.aa_version, AAVersion::V08);
 
+        // Test V07
+        let user_op = UserOperation::new(
+            sender,
+            Uint256::from(1),
+            b"",
+            0,
+            0,
+            0,
+            0,
+            0,
+            None,
+            Some(b""),
+            None,
+            Some(0),
+            Some(0),
+            Some(b""),
+        );
+        let request_v08 = UserOperationSignatureRequest::new(
+            user_op,
+            1,
+            137,
+            AAVersion::V07,
+            Some(&Context::new("test_context")),
+        );
+
+        let bytes = request_v08.to_bytes();
+        let deserialized_v08 = UserOperationSignatureRequest::from_bytes(&bytes).unwrap();
+        assert_eq!(deserialized_v08.aa_version, AAVersion::V07);
+
         // Test MDT
         let sender_mdt = Address::from_str("0xabcdef0123456789abcdef0123456789abcdef01").unwrap();
         let user_op_mdt = UserOperation::new(
@@ -1582,8 +1663,17 @@ mod tests {
             b"paymaster_and_data",
         );
 
+        // v07 which should error because v07 does not use EIP-712 structs for signing
+        let eip712_struct_v07 = packed_user_op.to_eip712_struct(&AAVersion::V07, 137);
+        assert!(eip712_struct_v07.is_err());
+        assert!(eip712_struct_v07
+            .unwrap_err()
+            .contains("Not supported for AA v0.7.0 since it does not use EIP-712 signatures"));
+
         // v08
-        let eip712_struct_v08 = packed_user_op.to_eip712_struct(&AAVersion::V08, 137);
+        let eip712_struct_v08 = packed_user_op
+            .to_eip712_struct(&AAVersion::V08, 137)
+            .unwrap();
 
         assert_eq!(
             eip712_struct_v08.get("primaryType").unwrap(),
@@ -1603,7 +1693,9 @@ mod tests {
         validate_eip712_message(v08_message.as_object().unwrap(), &packed_user_op, true);
 
         // mdt version
-        let eip712_struct_mdt = packed_user_op.to_eip712_struct(&AAVersion::MDT, 137);
+        let eip712_struct_mdt = packed_user_op
+            .to_eip712_struct(&AAVersion::MDT, 137)
+            .unwrap();
         assert_eq!(
             eip712_struct_mdt.get("primaryType").unwrap(),
             &JsonValue::String("PackedUserOperation".into())
@@ -1620,6 +1712,41 @@ mod tests {
         validate_eip712_domain(&mdt_domain, &packed_user_op, false);
         let mdt_message = eip712_struct_mdt.get("message").unwrap();
         validate_eip712_message(mdt_message.as_object().unwrap(), &packed_user_op, false);
+    }
+
+    #[test]
+    fn test_packed_user_operation_to_v07_encoding() {
+        let sender = Address::from_str("0x1234567890123456789012345678901234567890").unwrap();
+        let packed_user_op = PackedUserOperation::new(
+            sender,
+            Uint256::from(42),
+            b"init_code",
+            b"call_data",
+            b"account_gas_limits",
+            50000,
+            b"gas_fees",
+            b"paymaster_and_data",
+        );
+
+        let encoded_data = packed_user_op.to_v07_encoding(137);
+        // The encoded data should be the ABI encoding of the PackedUserOperation struct with the correct fields
+        let decoded = ethers::abi::decode(
+            &[
+                ethers::abi::ParamType::FixedBytes(32), // keccak256(abi.encode(packedUserOp))
+                ethers::abi::ParamType::Address,        // v07 entrypoint contract
+                ethers::abi::ParamType::Uint(256),      // chainId
+            ],
+            &encoded_data,
+        )
+        .unwrap();
+        assert_eq!(
+            decoded[1].clone().into_address().unwrap(),
+            ethers::types::H160::from_slice(Address::from_str(ENTRYPOINT_V07).unwrap().as_ref())
+        );
+        assert_eq!(
+            decoded[2].clone().into_uint().unwrap(),
+            ethers::types::U256::from(137)
+        );
     }
 
     #[test]

--- a/nucypher-core/src/signature_request.rs
+++ b/nucypher-core/src/signature_request.rs
@@ -65,6 +65,9 @@ pub const ENTRYPOINT_V07: &str = "0x0000000071727De22E5E9d8BAf0edAc6f37da032";
 /// AA version enum for Account Abstraction versions
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AAVersion {
+    /// Version 0.7.0
+    #[serde(rename = "0.7.0")]
+    V07,
     /// Version 0.8.0
     #[serde(rename = "0.8.0")]
     V08,
@@ -77,6 +80,7 @@ impl AAVersion {
     /// Return the string representation
     pub fn as_str(&self) -> &'static str {
         match self {
+            Self::V07 => "0.7.0",
             Self::V08 => "0.8.0",
             Self::MDT => "mdt",
         }
@@ -88,6 +92,7 @@ impl FromStr for AAVersion {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
+            "0.7.0" => Ok(Self::V07),
             "0.8.0" => Ok(Self::V08),
             "mdt" => Ok(Self::MDT),
             _ => Err(format!("Invalid AA version: {}", s)),
@@ -98,6 +103,7 @@ impl FromStr for AAVersion {
 impl fmt::Display for AAVersion {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::V07 => write!(f, "{}", Self::V07.as_str()),
             Self::V08 => write!(f, "{}", Self::V08.as_str()),
             Self::MDT => write!(f, "{}", Self::MDT.as_str()),
         }
@@ -1052,11 +1058,14 @@ mod tests {
 
     #[test]
     fn test_aa_version() {
+        assert_eq!(AAVersion::from_str("0.7.0").unwrap(), AAVersion::V07);
         assert_eq!(AAVersion::from_str("0.8.0").unwrap(), AAVersion::V08);
         assert_eq!(AAVersion::from_str("mdt").unwrap(), AAVersion::MDT);
+
         let result = AAVersion::from_str("invalid_version");
         assert!(result.unwrap_err().contains("Invalid AA version"));
 
+        assert_eq!(AAVersion::V07.to_string(), "0.7.0",);
         assert_eq!(AAVersion::V08.to_string(), "0.8.0",);
         assert_eq!(AAVersion::MDT.to_string(), "mdt",);
     }

--- a/nucypher-core/src/signature_request.rs
+++ b/nucypher-core/src/signature_request.rs
@@ -1328,7 +1328,7 @@ mod tests {
             Some(0),
             Some(b""),
         );
-        let request_v08 = UserOperationSignatureRequest::new(
+        let request_v07 = UserOperationSignatureRequest::new(
             user_op,
             1,
             137,
@@ -1336,9 +1336,9 @@ mod tests {
             Some(&Context::new("test_context")),
         );
 
-        let bytes = request_v08.to_bytes();
-        let deserialized_v08 = UserOperationSignatureRequest::from_bytes(&bytes).unwrap();
-        assert_eq!(deserialized_v08.aa_version, AAVersion::V07);
+        let bytes = request_v07.to_bytes();
+        let deserialized_v07 = UserOperationSignatureRequest::from_bytes(&bytes).unwrap();
+        assert_eq!(deserialized_v07.aa_version, AAVersion::V07);
 
         // Test MDT
         let sender_mdt = Address::from_str("0xabcdef0123456789abcdef0123456789abcdef01").unwrap();


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
- Implement canonical AA v07 support.
- Facilitates usage by Rhinestone SDK
- Cleanup based on CI builds
   - mypy failures
   - clippy warning
   - end-of-life node versions used in CI   


**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
